### PR TITLE
fix: various fixes

### DIFF
--- a/gulp.utils.js
+++ b/gulp.utils.js
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'url';
 import { deleteAsync } from 'del';
 import unzip from 'extract-zip';
 import { marked } from 'marked';
+import { moveFile } from 'move-file';
 import TJS from 'typescript-json-schema';
 
 const swaggerJSONPath = path.join('static', 'docs', 'swagger.json');
@@ -117,6 +118,7 @@ export const generateSchemas = async (cb) => {
 export const pullUblockOrigin = async (cb) => {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const zipFile = os.tmpdir() + '/ublock.zip';
+  const tmpUblockPath = path.join(os.tmpdir(), 'uBlock0.chromium'); // uBlock0.chromium is always the prod name
   const extensionsDir = join(__dirname, 'extensions');
   const uBlockDir = join(extensionsDir, 'ublock');
 
@@ -139,11 +141,10 @@ export const pullUblockOrigin = async (cb) => {
   );
   const json = await data.json();
   await downloadUrlToDirectory(json.assets[0].browser_download_url, zipFile);
-  await unzip(zipFile, { dir: join(__dirname, 'extensions') });
-  // uBlock0.chromium is always the prod name
-  await fs.rename(
-    join(extensionsDir, 'uBlock0.chromium'),
-    join('extensions', 'ublock'),
+  await unzip(zipFile, { dir: os.tmpdir() });
+  await moveFile(
+    join(tmpUblockPath),
+    join(extensionsDir, 'ublock'),
   );
   await deleteAsync(zipFile, { force: true }).catch((err) => {
     console.warn('Could not delete temporary download file: ' + err.message);

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "gulp-typescript": "^6.0.0-alpha.1",
         "marked": "^9.1.5",
         "mocha": "^10.0.0",
+        "move-file": "^3.1.0",
         "nodemon": "^3.0.1",
         "prettier": "^3.0.3",
         "sinon": "^17.0.1",
@@ -7851,6 +7852,30 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/move-file": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/move-file/-/move-file-3.1.0.tgz",
+      "integrity": "sha512-4aE3U7CCBWgrQlQDMq8da4woBWDGHioJFiOZ8Ie6Yq2uwYQ9V2kGhTz4x3u6Wc+OU17nw0yc3rJ/lQ4jIiPe3A==",
+      "dev": true,
+      "dependencies": {
+        "path-exists": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/move-file/node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "gulp build",
     "build:client": "gulp build:client",
     "clean": "gulp clean",
-    "dev": "gulp build:dev && env-cmd -f ./.env.dev gulp serve:dev",
+    "dev": "gulp build:dev && env-cmd -f ./.env gulp serve:dev",
     "prettier": "gulp prettier",
     "lint": "eslint . --ext .ts --fix",
     "install:dev": "gulp install:dev",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "gulp build",
     "build:client": "gulp build:client",
     "clean": "gulp clean",
-    "dev": "gulp build:dev && env-cmd -f ./.env gulp serve:dev",
+    "dev": "gulp build:dev && env-cmd -f ./.env.dev gulp serve:dev",
     "prettier": "gulp prettier",
     "lint": "eslint . --ext .ts --fix",
     "install:dev": "gulp install:dev",
@@ -51,6 +51,7 @@
     "gulp-typescript": "^6.0.0-alpha.1",
     "marked": "^9.1.5",
     "mocha": "^10.0.0",
+    "move-file": "^3.1.0",
     "nodemon": "^3.0.1",
     "prettier": "^3.0.3",
     "sinon": "^17.0.1",
@@ -76,15 +77,22 @@
     "systeminformation": "^5.17.12"
   },
   "mocha": {
-    "extension": ["ts"],
+    "extension": [
+      "ts"
+    ],
     "loader": "ts-node/esm",
     "spec": "src/**/*.spec.ts",
     "timeout": 30000,
     "slow": 5000
   },
-  "nodemon": {
-    "ignoreRoot": [".git", ".no-git"],
-    "watch": ["src"],
+  "nodemonConfig": {
+    "ignoreRoot": [
+      ".git",
+      ".no-git"
+    ],
+    "watch": [
+      "src"
+    ],
     "exec": "npx tsc && node ./build/index.js",
     "ext": "ts json",
     "signal": "SIGTERM"
@@ -94,5 +102,5 @@
     "trailingComma": "all",
     "singleQuote": true,
     "printWidth": 80
-  }    
+  }
 }


### PR DESCRIPTION
- Pull uBlock task: On the current implementation, the task unzips the uBlock zip directly into `extensions` and renames it. This can throw permissions errors, specially on Windows

- nodemon: the `dev` task wasn't working because nodemon wasn't pulling the config

- Default env file: If you clone the repo and try to run the `dev` task right away, it will fail because it's trying to use `.env` as envfile. Changed to `.env.dev`