### PR TITLE
fix proxy configuration for firefox and webkit

### DIFF
--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -224,6 +224,18 @@ export class BrowserManager {
       manualUserDataDir ||
       (Browser.name === CDPChromium.name ? await this.generateDataDir() : null);
 
+    const proxyServer =
+      launchOptions.args
+        ?.find((arg) => arg.includes('--proxy-server='))
+        ?.split('=')[1] ||
+      (launchOptions as BrowserServerOptions)?.proxy?.server;
+
+    if (proxyServer) {
+      (launchOptions as BrowserServerOptions).proxy = (
+        launchOptions as BrowserServerOptions
+      ).proxy || { server: proxyServer };
+    }
+
     const browser = new Browser({
       blockAds,
       config: this.config,

--- a/src/browsers/playwright-firefox.ts
+++ b/src/browsers/playwright-firefox.ts
@@ -86,9 +86,12 @@ export class PlaywrightFirefox extends EventEmitter {
     this.debug(`Launching Firefox Handler`);
 
     this.browser = await playwright.firefox.launchServer({
-      ...options,
-      args: [this.userDataDir ? `-profile=${this.userDataDir}` : ''],
+      args: [
+        ...(options.args || []),
+        this.userDataDir ? `-profile=${this.userDataDir}` : '',
+      ],
       executablePath: playwright.firefox.executablePath(),
+      proxy: options.proxy,
     });
 
     const browserWSEndpoint = this.browser.wsEndpoint();

--- a/src/browsers/playwright-webkit.ts
+++ b/src/browsers/playwright-webkit.ts
@@ -86,9 +86,12 @@ export class PlaywrightWebkit extends EventEmitter {
     this.debug(`Launching WebKit Handler`);
 
     this.browser = await playwright.webkit.launchServer({
-      ...options,
-      args: [this.userDataDir ? `-profile=${this.userDataDir}` : ''],
+      args: [
+        ...(options.args || []),
+        this.userDataDir ? `-profile=${this.userDataDir}` : '',
+      ],
       executablePath: playwright.webkit.executablePath(),
+      proxy: options.proxy,
     });
 
     const browserWSEndpoint = this.browser.wsEndpoint();


### PR DESCRIPTION
since firefox and webkit do not support --proxy-server argument proxy server must be passed through BrowserServerOptions