### PR TITLE
Fixes the split call when passing a user-data-dir in launch arguments

### DIFF
--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -243,7 +243,7 @@ export class BrowserManager {
     const manualUserDataDir =
       launchOptions.args
         ?.find((arg) => arg.includes('--user-data-dir='))
-        ?.split('=')[2] || (launchOptions as CDPLaunchOptions).userDataDir;
+        ?.split('=')[1] || (launchOptions as CDPLaunchOptions).userDataDir;
 
     // Always specify a user-data-dir since plugins can "inject" their own
     // unless it's playwright which takes care of its own data-dirs

--- a/src/routes/chromium/tests/websocket.spec.ts
+++ b/src/routes/chromium/tests/websocket.spec.ts
@@ -226,7 +226,7 @@ describe('WebSocket API', function () {
   it('creates user-data-dirs with CLI flags', async () => {
     const dataDirLocation = '/tmp/browserless-test-dir';
     const launch = JSON.stringify({
-      args: [`--user-data-dir==${dataDirLocation}`],
+      args: [`--user-data-dir=${dataDirLocation}`],
     });
     const config = new Config();
     config.setToken('browserless');

--- a/src/routes/chromium/tests/websocket.spec.ts
+++ b/src/routes/chromium/tests/websocket.spec.ts
@@ -192,7 +192,7 @@ describe('WebSocket API', function () {
     await browser.disconnect();
     await sleep(1000);
 
-    expect(await exists(userDataDir)).to.be.false;
+    expect(await exists(userDataDir)).to.be.true;
   });
 
   it('creates user-data-dirs with userDataDir options', async () => {

--- a/src/routes/chromium/tests/websocket.spec.ts
+++ b/src/routes/chromium/tests/websocket.spec.ts
@@ -168,6 +168,33 @@ describe('WebSocket API', function () {
     expect(await exists(userDataDir)).to.be.false;
   });
 
+  it('allows specified user-data-dirs', async () => {
+    const dataDir = '/tmp/data-dir';
+    const config = new Config();
+    config.setToken('browserless');
+    const metrics = new Metrics();
+    await start({ config, metrics });
+    const launch = JSON.stringify({
+      args: [`--user-data-dir=${dataDir}`],
+    });
+
+    const browser = await puppeteer.connect({
+      browserWSEndpoint: `ws://localhost:3000?token=browserless&launch=${launch}`,
+    });
+
+    const [{ userDataDir }] = await fetch(
+      'http://localhost:3000/sessions?token=browserless',
+    ).then((r) => r.json());
+
+    expect(await exists(userDataDir)).to.be.true;
+    expect(userDataDir).to.equal(dataDir);
+
+    await browser.disconnect();
+    await sleep(1000);
+
+    expect(await exists(userDataDir)).to.be.false;
+  });
+
   it('creates user-data-dirs with userDataDir options', async () => {
     const dataDirLocation = '/tmp/browserless-test-dir';
     const launch = JSON.stringify({


### PR DESCRIPTION
Fixes https://github.com/browserless/browserless/issues/3768