### PR TITLE
Find existing pages and proxy them through, prettier

### DIFF
--- a/src/browsers/cdp-chromium.ts
+++ b/src/browsers/cdp-chromium.ts
@@ -344,15 +344,12 @@ export class CDPChromium extends EventEmitter {
         );
       }
       socket.once('close', resolve);
-
-      const [page] = await this.browser.pages();
-      const pageLocation = `/devtools/page/${this.getPageId(page)}`;
-
-      this.debug(`Proxying ${req.parsed.href} to page "${pageLocation}"`);
-
-      const target = new URL(pageLocation, this.browserWSEndpoint).href;
-
+      this.debug(`Proxying ${req.parsed.href}`);
+      const target = new URL(req.parsed.pathname, this.browserWSEndpoint).href;
       req.url = '';
+
+      // Delete headers known to cause issues
+      delete req.headers.origin;
 
       this.proxy.ws(
         req,

--- a/src/routes/chromium/tests/content.spec.ts
+++ b/src/routes/chromium/tests/content.spec.ts
@@ -1,4 +1,9 @@
-import { Browserless, Config, Metrics, sleep } from '@browserless.io/browserless';
+import {
+  Browserless,
+  Config,
+  Metrics,
+  sleep,
+} from '@browserless.io/browserless';
 import { expect } from 'chai';
 
 describe('/content API', function () {

--- a/src/routes/chromium/tests/page-websocket.spec.ts
+++ b/src/routes/chromium/tests/page-websocket.spec.ts
@@ -1,0 +1,109 @@
+import {
+  Browserless,
+  Config,
+  Metrics,
+} from '@browserless.io/browserless';
+import puppeteer, { Connection } from 'puppeteer-core';
+import { NodeWebSocketTransport } from 'puppeteer-core/lib/esm/puppeteer/node/NodeWebSocketTransport.js';
+import { expect } from 'chai';
+
+describe('WebSocket Page API', function () {
+  // Server shutdown can take a few seconds
+  // and so can these tests :/
+  this.timeout(5000);
+
+  let browserless: Browserless;
+
+  const start = ({
+    config = new Config(),
+    metrics = new Metrics(),
+  }: { config?: Config; metrics?: Metrics } = {}) => {
+    browserless = new Browserless({ config, metrics });
+    return browserless.start();
+  };
+
+  afterEach(async () => {
+    await browserless.stop();
+  });
+
+  it('forwards requests to running pages', async () => {
+    const config = new Config();
+    const metrics = new Metrics();
+    await start({ config, metrics });
+
+    const browser = await puppeteer.connect({
+      browserWSEndpoint: `ws://localhost:3000`,
+    });
+    const page = await browser.newPage();
+    await page.goto('https://example.com/');
+    // @ts-ignore
+    const pageId = page.target()._targetId;
+    const webSocketDebuggerUrl = `ws://localhost:3000/devtools/page/${pageId}`;
+
+    // Connect to raw page target
+    const cdp = new Connection(
+      webSocketDebuggerUrl,
+      await NodeWebSocketTransport.create(webSocketDebuggerUrl),
+    );
+
+    // Send a command
+    const result = await cdp.send('Page.enable');
+    await browser.close();
+    expect(result);
+  });
+
+  it('rejects unauthorized page requests', async () => {
+    const config = new Config();
+    config.setToken('browserless');
+    const metrics = new Metrics();
+    await start({ config, metrics });
+
+    const browser = await puppeteer.connect({
+      browserWSEndpoint: `ws://localhost:3000?token=browserless`,
+    });
+    const page = await browser.newPage();
+    await page.goto('https://example.com/');
+    // @ts-ignore
+    const pageId = page.target()._targetId;
+    const webSocketDebuggerUrl = `ws://localhost:3000/devtools/page/${pageId}`;
+
+    // Connect to raw page target without authorization
+    try {
+      new Connection(
+        webSocketDebuggerUrl,
+        await NodeWebSocketTransport.create(webSocketDebuggerUrl),
+      );
+    } catch (err: unknown) {
+      //@ts-ignore
+      expect(err.message).to.include('401');
+    } finally {
+      browser.close();
+    }
+  });
+
+  it('404s pages not found', async () => {
+    const config = new Config();
+    const metrics = new Metrics();
+    await start({ config, metrics });
+
+    const browser = await puppeteer.connect({
+      browserWSEndpoint: `ws://localhost:3000?token=browserless`,
+    });
+    const page = await browser.newPage();
+    await page.goto('https://example.com/');
+    const webSocketDebuggerUrl = `ws://localhost:3000/devtools/page/im-a-banana`;
+
+    // Connect to raw page target without authorization
+    try {
+      new Connection(
+        webSocketDebuggerUrl,
+        await NodeWebSocketTransport.create(webSocketDebuggerUrl),
+      );
+    } catch (err: unknown) {
+      //@ts-ignore
+      expect(err.message).to.include('404');
+    } finally {
+      browser.close();
+    }
+  });
+});

--- a/src/shim.ts
+++ b/src/shim.ts
@@ -36,7 +36,8 @@ export const shimLegacyRequests = (url: URL): URL => {
       typeof headless !== 'undefined' &&
       launchParams.headless === undefined
     ) {
-      launchParams.headless = headless === 'shell' ? 'shell' : headless !== 'false';
+      launchParams.headless =
+        headless === 'shell' ? 'shell' : headless !== 'false';
     }
 
     if (typeof slowMo !== 'undefined' && launchParams.slowMo === undefined) {


### PR DESCRIPTION
This adjustment assumes that the thing connecting to browserless on the /devtools/page route(s) has already started an active session.