### PR TITLE
fix: esbuild for windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.4.0-beta-3",
       "license": "SSPL",
       "dependencies": {
+        "@esbuild/win32-x64": "^0.20.1",
         "debug": "^4.3.2",
         "del": "^7.0.0",
         "enjoi": "^9.0.1",
@@ -89,6 +90,20 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.1.tgz",
+      "integrity": "sha512-0MBh53o6XtI6ctDnRMeQ+xoCN8kD2qI1rY1KgF/xdWQwoFeKou7puvDfV8/Wv4Ctx2rRpET/gGdz3YlNtNACSA==",
+      "cpu": [
+        "x64"
+      ],
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "tsconfig.json"
   ],
   "dependencies": {
+    "@esbuild/win32-x64": "^0.20.1",
     "debug": "^4.3.2",
     "del": "^7.0.0",
     "enjoi": "^9.0.1",


### PR DESCRIPTION
Adds `@esbuild/win32-x64` to dependencies 