### PR TITLE
BUG: Negative Client(s) are currently connected

### DIFF
--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -387,6 +387,8 @@ export class BrowserManager {
         const found = allPages.flat().find((b) => b.id === id);
 
         if (found) {
+          const session = this.browsers.get(found.browser)!;
+          ++session.numbConnected;
           return found.browser;
         }
 


### PR DESCRIPTION
I encountered this bug where the browser gets closed even if I'm still connected to a page `/devtools/page/*`, here's how what I did:

1. launch the browser (This increases `session.numbConnected`)
2. `page = browser.newPage()`
3. connect to `/devtools/page/${pageId}` and `Page.startScreencast` (This does not increases session.numbConnected)
4. I'm receiving frames, so I `browser.disconnect()` (I don't need to do anything anymore)
5. `/devtools/page/${pageId}` gets disconnected because browser was closed (Also this decreases `session.numbConnected`)

When I `browser.disconnect()`, the browser manager sees that `session.numbConnected == 0`  and closes the browser