### PR TITLE
New logging class + route handler API changes for injecting  logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # [Latest](https://github.com/browserless/chrome/compare/v2.7.1...main)
+**Potentially Breaking**
+- New `Logger` class and SDK primitives in support of that.
 - Dependency updates.
 
 # [v2.7.1](https://github.com/browserless/chrome/compare/v2.7.0...v2.7.1)

--- a/bin/browserless.js
+++ b/bin/browserless.js
@@ -152,6 +152,7 @@ const start = async (dev = false) => {
     Config,
     FileSystem,
     Limiter,
+    Logger,
     Metrics,
     Monitoring,
     Router,
@@ -164,6 +165,7 @@ const start = async (dev = false) => {
     importDefault(files, 'config'),
     importDefault(files, 'file-system'),
     importDefault(files, 'limiter'),
+    importDefault(files, 'logger'),
     importDefault(files, 'metrics'),
     importDefault(files, 'monitoring'),
     importDefault(files, 'router'),
@@ -197,6 +199,7 @@ const start = async (dev = false) => {
     : Router;
 
   const browserless = new Browserless({
+    Logger,
     browserManager,
     config,
     fileSystem,

--- a/bin/scaffold/README.md
+++ b/bin/scaffold/README.md
@@ -128,6 +128,7 @@ Internally, we use this same class-based system, so feel free to see how those w
 import {
   APITags,
   HTTPRoute,
+  Logger,
   Methods,
   contentTypes,
   writeResponse,
@@ -174,7 +175,7 @@ export default class HelloWorldRoute extends HTTPRoute {
   // Handler is a function, getting the request and response objects, and is where you'll write the
   // core logic behind this route. Use utilities like writeResponse or writeJSONResponse to help
   // return the appropriate response.
-  handler = async (_req, res): Promise<void> => {
+  handler = async (_req, res, _logger: Logger): Promise<void> => {
     const response: ResponseSchema = 'Hello World!';
     return writeResponse(res, 200, ResponseSchema, contentTypes.text);
   };
@@ -189,6 +190,7 @@ import {
   BrowserWebsocketRoute,
   ChromiumCDP,
   CDPLaunchOptions,
+  Logger,
   Request,
   SystemQueryParameters,
   WebsocketRoutes,
@@ -226,7 +228,7 @@ export default class ChromiumWebSocketRoute extends BrowserWebsocketRoute {
   // Routes with a browser type get a browser argument of the Browser instance, otherwise
   // request, socket, and head are the other 3 arguments. Here we pass them through
   // and proxy the request into Chromium to handle.
-  handler = async (req, socket, head, chromium): Promise<void> =>
+  handler = async (req, socket, head, logger, chromium): Promise<void> =>
     chromium.proxyWebSocket(req, socket, head);
 }
 ```
@@ -293,7 +295,7 @@ Then, later, in your route you can define some functionality and load the config
 
 ```ts
 // src/pdf.http.ts
-import { BrowserHTTPRoute } from '@browserless.io/browserless';
+import { BrowserHTTPRoute, Logger } from '@browserless.io/browserless';
 import MyConfig from './config';
 
 // Export the BodySchema for documentation site to parse, plus
@@ -342,7 +344,7 @@ export default class PDFToS3Route extends BrowserHTTPRoute {
   tags = [APITags.browserAPI];
 
   // Handler's are where we embed the logic that facilitates this route.
-  handler = async (req, res, browser): Promise<void> => {
+  handler = async (req, res, logger, browser): Promise<void> => {
     // Modules like Config are injected via this internal methods.
     // Use them to load core modules within the platform.
     const config = this.config() as MyConfig;

--- a/src/browserless.ts
+++ b/src/browserless.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import {
+  Logger as BlessLogger,
   BrowserHTTPRoute,
   BrowserManager,
   BrowserWebsocketRoute,
@@ -51,6 +52,7 @@ export class Browserless extends EventEmitter {
   protected fileSystem: FileSystem;
   protected hooks: Hooks;
   protected limiter: Limiter;
+  protected Logger: typeof BlessLogger;
   protected metrics: Metrics;
   protected monitoring: Monitoring;
   protected router: Router;
@@ -71,12 +73,14 @@ export class Browserless extends EventEmitter {
     fileSystem,
     hooks,
     limiter,
+    Logger: LoggerOverride,
     metrics,
     monitoring,
     router,
     token,
     webhooks,
   }: {
+    Logger?: Browserless['Logger'];
     browserManager?: Browserless['browserManager'];
     config?: Browserless['config'];
     fileSystem?: Browserless['fileSystem'];
@@ -89,6 +93,7 @@ export class Browserless extends EventEmitter {
     webhooks?: Browserless['webhooks'];
   } = {}) {
     super();
+    this.Logger = LoggerOverride ?? BlessLogger;
     this.config = config || new Config();
     this.metrics = metrics || new Metrics();
     this.token = token || new Token(this.config);
@@ -108,7 +113,8 @@ export class Browserless extends EventEmitter {
         this.hooks,
       );
     this.router =
-      router || new Router(this.config, this.browserManager, this.limiter);
+      router ||
+      new Router(this.config, this.browserManager, this.limiter, this.Logger);
   }
 
   protected saveMetrics = async (): Promise<void> => {
@@ -360,6 +366,7 @@ export class Browserless extends EventEmitter {
       this.token,
       this.router,
       this.hooks,
+      this.Logger,
     );
 
     await this.server.start();

--- a/src/browserless.ts
+++ b/src/browserless.ts
@@ -235,7 +235,6 @@ export class Browserless extends EventEmitter {
       ...internalHttpRouteFiles,
     ]) {
       if (httpRoute.endsWith('js')) {
-        const { name } = path.parse(httpRoute);
         const [bodySchema, querySchema] = await Promise.all(
           routeSchemas.map(async (schemaType) => {
             const schemaPath = path.parse(httpRoute);
@@ -249,7 +248,6 @@ export class Browserless extends EventEmitter {
         const routeImport = `${
           this.config.getIsWin() ? 'file:///' : ''
         }${httpRoute}`;
-        const logger = createLogger(`http:${name}`);
         const {
           default: Route,
         }: { default: Implements<HTTPRoute> | Implements<BrowserHTTPRoute> } =
@@ -258,7 +256,6 @@ export class Browserless extends EventEmitter {
           this.browserManager,
           this.config,
           this.fileSystem,
-          logger,
           this.metrics,
           this.monitoring,
           this.staticSDKDir,
@@ -271,7 +268,6 @@ export class Browserless extends EventEmitter {
           route.metrics = () => this.metrics;
           route.monitoring = () => this.monitoring;
           route.fileSystem = () => this.fileSystem;
-          route.debug = () => logger;
           route.staticSDKDir = () => this.staticSDKDir;
 
           httpRoutes.push(route);
@@ -285,7 +281,6 @@ export class Browserless extends EventEmitter {
       ...internalWsRouteFiles,
     ]) {
       if (wsRoute.endsWith('js')) {
-        const { name } = path.parse(wsRoute);
         const [, querySchema] = await Promise.all(
           routeSchemas.map(async (schemaType) => {
             const schemaPath = path.parse(wsRoute);
@@ -299,7 +294,6 @@ export class Browserless extends EventEmitter {
         const wsImport = `${
           this.config.getIsWin() ? 'file:///' : ''
         }${wsRoute}`;
-        const logger = createLogger(`ws:${name}`);
         const {
           default: Route,
         }: {
@@ -311,7 +305,6 @@ export class Browserless extends EventEmitter {
           this.browserManager,
           this.config,
           this.fileSystem,
-          logger,
           this.metrics,
           this.monitoring,
           this.staticSDKDir,
@@ -323,7 +316,6 @@ export class Browserless extends EventEmitter {
           route.metrics = () => this.metrics;
           route.monitoring = () => this.monitoring;
           route.fileSystem = () => this.fileSystem;
-          route.debug = () => logger;
           route.staticSDKDir = () => this.staticSDKDir;
 
           wsRoutes.push(route);

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -6,6 +6,7 @@ export * from './file-system.js';
 export * from './hooks.js';
 export * from './http.js';
 export * from './limiter.js';
+export * from './logger.js';
 export * from './metrics.js';
 export * from './mime-types.js';
 export * from './monitoring.js';

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,21 @@
+import { Request, createLogger } from '@browserless.io/browserless';
+
+export class Logger {
+  protected debugger: ReturnType<typeof createLogger>;
+
+  constructor(
+    protected prefix: string,
+    protected request: Request,
+  ) {
+    this.debugger = createLogger(prefix);
+  }
+
+  public extend(prefix: string) {
+    return new Logger(this.prefix + prefix, this.request);
+  }
+
+  public log(...messages: string[]) {
+    const ip = this.request.socket.remoteAddress ?? 'Unknown';
+    this.debugger(ip, ...messages);
+  }
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,21 +1,31 @@
 import { Request, createLogger } from '@browserless.io/browserless';
 
 export class Logger {
-  protected debugger: ReturnType<typeof createLogger>;
+  protected _log: ReturnType<typeof createLogger>;
+  protected _verbose: ReturnType<typeof createLogger>;
+  protected _error: ReturnType<typeof createLogger>;
 
   constructor(
     protected prefix: string,
     protected request: Request,
   ) {
-    this.debugger = createLogger(prefix);
+    this._log = createLogger(prefix);
+    this._verbose = this._log.extend('verbose');
+    this._error = this._log.extend('error');
   }
 
-  public extend(prefix: string) {
-    return new Logger(this.prefix + prefix, this.request);
+  public verbose(...messages: string[]) {
+    const ip = this.request.socket.remoteAddress ?? 'Unknown';
+    this._verbose(ip, ...messages);
   }
 
   public log(...messages: string[]) {
     const ip = this.request.socket.remoteAddress ?? 'Unknown';
-    this.debugger(ip, ...messages);
+    this._log(ip, ...messages);
+  }
+
+  public error(...messages: string[]) {
+    const ip = this.request.socket.remoteAddress ?? 'Unknown';
+    this._error(ip, ...messages);
   }
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -31,6 +31,7 @@ export class Router extends EventEmitter {
     protected config: Config,
     protected browserManager: BrowserManager,
     protected limiter: Limiter,
+    protected logger: typeof Logger,
   ) {
     super();
   }
@@ -71,7 +72,7 @@ export class Router extends EventEmitter {
         this.log(`HTTP Request has closed prior to running`);
         return Promise.resolve();
       }
-      const logger = new Logger(route.name, req);
+      const logger = new this.logger(route.name, req);
       if ('browser' in route && route.browser) {
         const browser = await this.browserManager.getBrowserForRequest(
           req,
@@ -121,7 +122,7 @@ export class Router extends EventEmitter {
         this.log(`WebSocket Request has closed prior to running`);
         return Promise.resolve();
       }
-      const logger = new Logger(route.name, req);
+      const logger = new this.logger(route.name, req);
       if ('browser' in route && route.browser) {
         const browser = await this.browserManager.getBrowserForRequest(
           req,

--- a/src/routes/firefox/ws/playwright.ts
+++ b/src/routes/firefox/ws/playwright.ts
@@ -5,6 +5,7 @@ import {
   BrowserWebsocketRoute,
   BrowserlessRoutes,
   FirefoxPlaywright,
+  Logger,
   Request,
   SystemQueryParameters,
   WebsocketRoutes,
@@ -29,6 +30,7 @@ export default class FirefoxPlaywrightWebSocketRoute extends BrowserWebsocketRou
     req: Request,
     socket: Duplex,
     head: Buffer,
+    _logger: Logger,
     browser: FirefoxPlaywright,
   ): Promise<void> => {
     const isPlaywright = req.headers['user-agent']

--- a/src/routes/management/http/static.get.ts
+++ b/src/routes/management/http/static.get.ts
@@ -38,7 +38,7 @@ const streamFile = (
     return createReadStream(file)
       .on('error', (error) => {
         if (error) {
-          logger.log(`Error finding file ${file}, sending 404`);
+          logger.error(`Error finding file ${file}, sending 404`);
           pathMap.delete(file);
           return reject(
             new NotFound(`Request for file "${file}" was not found`),
@@ -67,10 +67,9 @@ export default class StaticGetRoute extends HTTPRoute {
   ): Promise<unknown> => {
     const { pathname } = req.parsed;
     const fileCache = pathMap.get(pathname);
-    const verbose = logger.extend('verbose');
 
     if (fileCache) {
-      return streamFile(verbose, res, fileCache.path, fileCache.contentType);
+      return streamFile(logger, res, fileCache.path, fileCache.contentType);
     }
 
     const config = this.config();
@@ -103,7 +102,9 @@ export default class StaticGetRoute extends HTTPRoute {
     }
 
     const [foundFilePath] = foundFilePaths;
-    verbose.log(`Found new file "${foundFilePath}", caching path and serving`);
+    logger.verbose(
+      `Found new file "${foundFilePath}", caching path and serving`,
+    );
 
     const contentType = mimeTypes.get(path.extname(foundFilePath));
 
@@ -117,6 +118,6 @@ export default class StaticGetRoute extends HTTPRoute {
       path: foundFilePath,
     });
 
-    return streamFile(verbose, res, foundFilePath, contentType);
+    return streamFile(logger, res, foundFilePath, contentType);
   };
 }

--- a/src/routes/webkit/ws/playwright.ts
+++ b/src/routes/webkit/ws/playwright.ts
@@ -4,6 +4,7 @@ import {
   BrowserServerOptions,
   BrowserWebsocketRoute,
   BrowserlessRoutes,
+  Logger,
   Request,
   SystemQueryParameters,
   WebkitPlaywright,
@@ -27,6 +28,7 @@ export default class WebKitPlaywrightWebSocketRoute extends BrowserWebsocketRout
     req: Request,
     socket: Duplex,
     head: Buffer,
+    _logger: Logger,
     browser: WebkitPlaywright,
   ): Promise<void> => {
     const isPlaywright = req.headers['user-agent']

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import {
   Config,
   HTTPRoute,
   Hooks,
+  Logger,
   Metrics,
   NotFound,
   Request,
@@ -263,7 +264,7 @@ export class HTTPServer extends EventEmitter {
     }
 
     return (route as HTTPRoute)
-      .handler(req, res)
+      .handler(req, res, new Logger(route.name, req))
       .then(() => {
         this.verbose('HTTP connection complete');
       })
@@ -368,7 +369,7 @@ export class HTTPServer extends EventEmitter {
       }
 
       return (route as WebSocketRoute)
-        .handler(req, socket, head)
+        .handler(req, socket, head, new Logger(route.name, req))
         .then(() => {
           this.verbose('Websocket connection complete');
         })

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,10 +2,10 @@ import * as http from 'http';
 import * as stream from 'stream';
 import {
   BadRequest,
+  Logger as BlessLogger,
   Config,
   HTTPRoute,
   Hooks,
-  Logger,
   Metrics,
   NotFound,
   Request,
@@ -50,6 +50,7 @@ export class HTTPServer extends EventEmitter {
     protected token: Token,
     protected router: Router,
     protected hooks: Hooks,
+    protected Logger: typeof BlessLogger,
   ) {
     super();
     this.host = config.getHost();
@@ -264,7 +265,7 @@ export class HTTPServer extends EventEmitter {
     }
 
     return (route as HTTPRoute)
-      .handler(req, res, new Logger(route.name, req))
+      .handler(req, res, new this.Logger(route.name, req))
       .then(() => {
         this.verbose('HTTP connection complete');
       })
@@ -369,7 +370,7 @@ export class HTTPServer extends EventEmitter {
       }
 
       return (route as WebSocketRoute)
-        .handler(req, socket, head, new Logger(route.name, req))
+        .handler(req, socket, head, new this.Logger(route.name, req))
         .then(() => {
           this.verbose('Websocket connection complete');
         })

--- a/src/shared/browser.ws.ts
+++ b/src/shared/browser.ws.ts
@@ -4,6 +4,7 @@ import {
   BrowserlessRoutes,
   CDPLaunchOptions,
   ChromiumCDP,
+  Logger,
   Request,
   SystemQueryParameters,
   WebsocketRoutes,
@@ -31,6 +32,7 @@ export default class ChromiumBrowserWebSocketRoute extends BrowserWebsocketRoute
     req: Request,
     socket: Duplex,
     head: Buffer,
+    _logger: Logger,
     browser: ChromiumCDP,
   ): Promise<void> => browser.proxyWebSocket(req, socket, head);
 }

--- a/src/shared/chromium.playwright.ws.ts
+++ b/src/shared/chromium.playwright.ws.ts
@@ -5,6 +5,7 @@ import {
   BrowserWebsocketRoute,
   BrowserlessRoutes,
   ChromiumPlaywright,
+  Logger,
   Request,
   SystemQueryParameters,
   WebsocketRoutes,
@@ -30,6 +31,7 @@ export default class ChromiumPlaywrightWebSocketRoute extends BrowserWebsocketRo
     req: Request,
     socket: Duplex,
     head: Buffer,
+    _logger: Logger,
     browser: ChromiumPlaywright,
   ): Promise<void> => {
     const isPlaywright = req.headers['user-agent']

--- a/src/shared/chromium.ws.ts
+++ b/src/shared/chromium.ws.ts
@@ -4,6 +4,7 @@ import {
   BrowserlessRoutes,
   CDPLaunchOptions,
   ChromiumCDP,
+  Logger,
   Request,
   SystemQueryParameters,
   WebsocketRoutes,
@@ -26,6 +27,7 @@ export default class ChromiumCDPWebSocketRoute extends BrowserWebsocketRoute {
     req: Request,
     socket: Duplex,
     head: Buffer,
+    _logger: Logger,
     browser: ChromiumCDP,
   ): Promise<void> => browser.proxyWebSocket(req, socket, head);
 }

--- a/src/shared/content.http.ts
+++ b/src/shared/content.http.ts
@@ -7,6 +7,7 @@ import {
   CDPLaunchOptions,
   ChromiumCDP,
   HTTPRoutes,
+  Logger,
   Methods,
   Request,
   SystemQueryParameters,
@@ -77,6 +78,7 @@ export default class ChromiumContentPostRoute extends BrowserHTTPRoute {
   handler = async (
     req: Request,
     res: ServerResponse,
+    _logger: Logger,
     browser: BrowserInstance,
   ): Promise<void> => {
     const contentType =

--- a/src/shared/download.http.ts
+++ b/src/shared/download.http.ts
@@ -72,11 +72,11 @@ export default class ChromiumDownloadPostRoute extends BrowserHTTPRoute {
         `.browserless.download.${id()}`,
       );
 
-      logger.log(`Generating a download directory at "${downloadPath}"`);
+      logger._log(`Generating a download directory at "${downloadPath}"`);
       await mkdir(downloadPath);
       const handler = functionHandler(config, logger, { downloadPath });
       const response = await handler(req, browser).catch((e) => {
-        logger.log(`Error running download code handler: "${e}"`);
+        logger._log(`Error running download code handler: "${e}"`);
         reject(e);
         return null;
       });
@@ -86,10 +86,10 @@ export default class ChromiumDownloadPostRoute extends BrowserHTTPRoute {
       }
 
       const { page } = response;
-      logger.log(`Download function has returned, finding downloads...`);
+      logger._log(`Download function has returned, finding downloads...`);
       async function checkIfDownloadComplete(): Promise<string | null> {
         if (res.headersSent) {
-          logger.log(
+          logger._log(
             `Request headers have been sent, terminating download watch.`,
           );
           return null;
@@ -100,13 +100,13 @@ export default class ChromiumDownloadPostRoute extends BrowserHTTPRoute {
           return checkIfDownloadComplete();
         }
 
-        logger.log(`All files have finished downloading`);
+        logger._log(`All files have finished downloading`);
 
         return path.join(downloadPath, fileName);
       }
 
       const filePath = await checkIfDownloadComplete();
-      logger.log(`Closing pages.`);
+      logger._log(`Closing pages.`);
       page.close();
       page.removeAllListeners();
 
@@ -115,12 +115,12 @@ export default class ChromiumDownloadPostRoute extends BrowserHTTPRoute {
           filePath &&
           deleteAsync(filePath, { force: true })
             .then(() => {
-              logger.log(
+              logger._log(
                 `Successfully deleted downloads from disk at "${filePath}"`,
               );
             })
             .catch((err) => {
-              logger.log(
+              logger._log(
                 `Error cleaning up downloaded files: "${err}" at "${filePath}"`,
               );
             }),
@@ -147,7 +147,7 @@ export default class ChromiumDownloadPostRoute extends BrowserHTTPRoute {
           }
         })
         .on('end', () => {
-          logger.log(`Downloads successfully sent`);
+          logger._log(`Downloads successfully sent`);
           rmDownload();
           return resolve();
         })

--- a/src/shared/download.http.ts
+++ b/src/shared/download.http.ts
@@ -72,11 +72,11 @@ export default class ChromiumDownloadPostRoute extends BrowserHTTPRoute {
         `.browserless.download.${id()}`,
       );
 
-      logger._log(`Generating a download directory at "${downloadPath}"`);
+      logger.log(`Generating a download directory at "${downloadPath}"`);
       await mkdir(downloadPath);
       const handler = functionHandler(config, logger, { downloadPath });
       const response = await handler(req, browser).catch((e) => {
-        logger._log(`Error running download code handler: "${e}"`);
+        logger.log(`Error running download code handler: "${e}"`);
         reject(e);
         return null;
       });
@@ -86,10 +86,10 @@ export default class ChromiumDownloadPostRoute extends BrowserHTTPRoute {
       }
 
       const { page } = response;
-      logger._log(`Download function has returned, finding downloads...`);
+      logger.log(`Download function has returned, finding downloads...`);
       async function checkIfDownloadComplete(): Promise<string | null> {
         if (res.headersSent) {
-          logger._log(
+          logger.log(
             `Request headers have been sent, terminating download watch.`,
           );
           return null;
@@ -100,13 +100,13 @@ export default class ChromiumDownloadPostRoute extends BrowserHTTPRoute {
           return checkIfDownloadComplete();
         }
 
-        logger._log(`All files have finished downloading`);
+        logger.log(`All files have finished downloading`);
 
         return path.join(downloadPath, fileName);
       }
 
       const filePath = await checkIfDownloadComplete();
-      logger._log(`Closing pages.`);
+      logger.log(`Closing pages.`);
       page.close();
       page.removeAllListeners();
 
@@ -115,12 +115,12 @@ export default class ChromiumDownloadPostRoute extends BrowserHTTPRoute {
           filePath &&
           deleteAsync(filePath, { force: true })
             .then(() => {
-              logger._log(
+              logger.log(
                 `Successfully deleted downloads from disk at "${filePath}"`,
               );
             })
             .catch((err) => {
-              logger._log(
+              logger.log(
                 `Error cleaning up downloaded files: "${err}" at "${filePath}"`,
               );
             }),
@@ -147,7 +147,7 @@ export default class ChromiumDownloadPostRoute extends BrowserHTTPRoute {
           }
         })
         .on('end', () => {
-          logger._log(`Downloads successfully sent`);
+          logger.log(`Downloads successfully sent`);
           rmDownload();
           return resolve();
         })

--- a/src/shared/function.http.ts
+++ b/src/shared/function.http.ts
@@ -65,7 +65,7 @@ export default class ChromiumFunctionPostRoute extends BrowserHTTPRoute {
     const handler = functionHandler(config, logger);
     const { contentType, payload, page } = await handler(req, browser);
 
-    logger.log(`Got function response of "${contentType}"`);
+    logger._log(`Got function response of "${contentType}"`);
     page.close();
     page.removeAllListeners();
 
@@ -77,7 +77,7 @@ export default class ChromiumFunctionPostRoute extends BrowserHTTPRoute {
       if (!type) {
         throw new BadRequest(`Couldn't determine function's response type.`);
       } else {
-        logger.log(`Sending file-type response of "${type}"`);
+        logger._log(`Sending file-type response of "${type}"`);
         const readStream = new Stream.PassThrough();
         readStream.end(response);
         res.setHeader('Content-Type', type);

--- a/src/shared/function.http.ts
+++ b/src/shared/function.http.ts
@@ -7,6 +7,7 @@ import {
   CDPLaunchOptions,
   ChromiumCDP,
   HTTPRoutes,
+  Logger,
   Methods,
   Request,
   SystemQueryParameters,
@@ -57,14 +58,14 @@ export default class ChromiumFunctionPostRoute extends BrowserHTTPRoute {
   handler = async (
     req: Request,
     res: ServerResponse,
+    logger: Logger,
     browser: BrowserInstance,
   ): Promise<void> => {
-    const debug = this.debug();
     const config = this.config();
-    const handler = functionHandler(config, debug);
+    const handler = functionHandler(config, logger);
     const { contentType, payload, page } = await handler(req, browser);
 
-    debug(`Got function response of "${contentType}"`);
+    logger.log(`Got function response of "${contentType}"`);
     page.close();
     page.removeAllListeners();
 
@@ -76,7 +77,7 @@ export default class ChromiumFunctionPostRoute extends BrowserHTTPRoute {
       if (!type) {
         throw new BadRequest(`Couldn't determine function's response type.`);
       } else {
-        debug(`Sending file-type response of "${type}"`);
+        logger.log(`Sending file-type response of "${type}"`);
         const readStream = new Stream.PassThrough();
         readStream.end(response);
         res.setHeader('Content-Type', type);

--- a/src/shared/function.http.ts
+++ b/src/shared/function.http.ts
@@ -65,7 +65,7 @@ export default class ChromiumFunctionPostRoute extends BrowserHTTPRoute {
     const handler = functionHandler(config, logger);
     const { contentType, payload, page } = await handler(req, browser);
 
-    logger._log(`Got function response of "${contentType}"`);
+    logger.log(`Got function response of "${contentType}"`);
     page.close();
     page.removeAllListeners();
 
@@ -77,7 +77,7 @@ export default class ChromiumFunctionPostRoute extends BrowserHTTPRoute {
       if (!type) {
         throw new BadRequest(`Couldn't determine function's response type.`);
       } else {
-        logger._log(`Sending file-type response of "${type}"`);
+        logger.log(`Sending file-type response of "${type}"`);
         const readStream = new Stream.PassThrough();
         readStream.end(response);
         res.setHeader('Content-Type', type);

--- a/src/shared/page.ws.ts
+++ b/src/shared/page.ws.ts
@@ -4,6 +4,7 @@ import {
   BrowserlessRoutes,
   CDPLaunchOptions,
   ChromiumCDP,
+  Logger,
   Request,
   SystemQueryParameters,
   WebsocketRoutes,
@@ -32,6 +33,7 @@ export default class ChromiumPageWebSocketRoute extends BrowserWebsocketRoute {
     req: Request,
     socket: Duplex,
     head: Buffer,
+    _logger: Logger,
     browser: ChromiumCDP,
   ): Promise<void> => browser.proxyPageWebSocket(req, socket, head);
 }

--- a/src/shared/pdf.http.ts
+++ b/src/shared/pdf.http.ts
@@ -7,6 +7,7 @@ import {
   CDPLaunchOptions,
   ChromiumCDP,
   HTTPRoutes,
+  Logger,
   Methods,
   Request,
   SystemQueryParameters,
@@ -83,6 +84,7 @@ export default class ChromiumPDFPostRoute extends BrowserHTTPRoute {
   handler = async (
     req: Request,
     res: ServerResponse,
+    _logger: Logger,
     browser: BrowserInstance,
   ): Promise<void> => {
     const contentType =

--- a/src/shared/performance.http.ts
+++ b/src/shared/performance.http.ts
@@ -6,6 +6,7 @@ import {
   CDPLaunchOptions,
   ChromiumCDP,
   HTTPRoutes,
+  Logger,
   Methods,
   Request,
   SystemQueryParameters,
@@ -47,6 +48,7 @@ export default class PerformancePost extends BrowserHTTPRoute {
   handler = async (
     req: Request,
     res: ServerResponse,
+    _logger: Logger,
     browser: BrowserInstance,
   ): Promise<void> => {
     const config = this.config();

--- a/src/shared/scrape.http.ts
+++ b/src/shared/scrape.http.ts
@@ -8,6 +8,7 @@ import {
   ChromiumCDP,
   HTTPRoutes,
   InBoundRequest,
+  Logger,
   Methods,
   OutBoundRequest,
   Request,
@@ -218,6 +219,7 @@ export default class ChromiumScrapePostRoute extends BrowserHTTPRoute {
   handler = async (
     req: Request,
     res: ServerResponse,
+    _logger: Logger,
     browser: BrowserInstance,
   ) => {
     const contentType =

--- a/src/shared/screenshot.http.ts
+++ b/src/shared/screenshot.http.ts
@@ -7,6 +7,7 @@ import {
   CDPLaunchOptions,
   ChromiumCDP,
   HTTPRoutes,
+  Logger,
   Methods,
   Request,
   SystemQueryParameters,
@@ -85,6 +86,7 @@ export default class ScreenshotPost extends BrowserHTTPRoute {
   handler = async (
     req: Request,
     res: ServerResponse,
+    _logger: Logger,
     browser: BrowserInstance,
   ): Promise<void> => {
     const contentType =

--- a/src/shared/utils/function/handler.ts
+++ b/src/shared/utils/function/handler.ts
@@ -84,7 +84,7 @@ export default (config: Config, logger: Logger, options: HandlerOptions = {}) =>
      */
     page.on('request', async (request) => {
       const requestUrl = request.url();
-      logger._log(`Outbound Page Request: "${requestUrl}"`);
+      logger.log(`Outbound Page Request: "${requestUrl}"`);
       if (requestUrl.startsWith(functionRequestPath)) {
         const filename = path.basename(requestUrl);
         if (filename === functionCodeJS) {
@@ -103,7 +103,7 @@ export default (config: Config, logger: Logger, options: HandlerOptions = {}) =>
             status: 200,
           });
         }
-        logger._log(
+        logger.log(
           `Static asset request to "${requestUrl}" couldn't be found, 404-ing`,
         );
         return request.respond({
@@ -112,18 +112,18 @@ export default (config: Config, logger: Logger, options: HandlerOptions = {}) =>
           status: 404,
         });
       }
-      logger._log(`Request: "${requestUrl}" no responder found, continuing...`);
+      logger.log(`Request: "${requestUrl}" no responder found, continuing...`);
       return request.continue();
     });
 
     page.on('response', (res) => {
       if (res.status() !== 200) {
-        logger._log(`Received a non-200 response for request "${res.url()}"`);
+        logger.log(`Received a non-200 response for request "${res.url()}"`);
       }
     });
 
     page.on('console', (event) => {
-      logger._log(`${event.type()}: ${event.text()}`);
+      logger.log(`${event.type()}: ${event.text()}`);
     });
 
     await page.goto(functionIndexHTML);
@@ -160,7 +160,7 @@ export default (config: Config, logger: Logger, options: HandlerOptions = {}) =>
         JSON.stringify(options),
       )
       .catch((e) => {
-        logger._log(`Error running code: ${e}`);
+        logger.log(`Error running code: ${e}`);
         throw new BadRequest(e.message);
       });
 

--- a/src/shared/utils/function/handler.ts
+++ b/src/shared/utils/function/handler.ts
@@ -84,7 +84,7 @@ export default (config: Config, logger: Logger, options: HandlerOptions = {}) =>
      */
     page.on('request', async (request) => {
       const requestUrl = request.url();
-      logger.log(`Outbound Page Request: "${requestUrl}"`);
+      logger._log(`Outbound Page Request: "${requestUrl}"`);
       if (requestUrl.startsWith(functionRequestPath)) {
         const filename = path.basename(requestUrl);
         if (filename === functionCodeJS) {
@@ -103,7 +103,7 @@ export default (config: Config, logger: Logger, options: HandlerOptions = {}) =>
             status: 200,
           });
         }
-        logger.log(
+        logger._log(
           `Static asset request to "${requestUrl}" couldn't be found, 404-ing`,
         );
         return request.respond({
@@ -112,18 +112,18 @@ export default (config: Config, logger: Logger, options: HandlerOptions = {}) =>
           status: 404,
         });
       }
-      logger.log(`Request: "${requestUrl}" no responder found, continuing...`);
+      logger._log(`Request: "${requestUrl}" no responder found, continuing...`);
       return request.continue();
     });
 
     page.on('response', (res) => {
       if (res.status() !== 200) {
-        logger.log(`Received a non-200 response for request "${res.url()}"`);
+        logger._log(`Received a non-200 response for request "${res.url()}"`);
       }
     });
 
     page.on('console', (event) => {
-      logger.log(`${event.type()}: ${event.text()}`);
+      logger._log(`${event.type()}: ${event.text()}`);
     });
 
     await page.goto(functionIndexHTML);
@@ -160,7 +160,7 @@ export default (config: Config, logger: Logger, options: HandlerOptions = {}) =>
         JSON.stringify(options),
       )
       .catch((e) => {
-        logger.log(`Error running code: ${e}`);
+        logger._log(`Error running code: ${e}`);
         throw new BadRequest(e.message);
       });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ import {
   FirefoxPlaywright,
   HTTPManagementRoutes,
   HTTPRoutes,
+  Logger,
   Methods,
   Metrics,
   Request,
@@ -99,7 +100,6 @@ abstract class Route {
     protected _browserManager: Browserless['browserManager'],
     protected _config: Browserless['config'],
     protected _fileSystem: Browserless['fileSystem'],
-    protected _debug: Browserless['debug'],
     protected _metrics: Browserless['metrics'],
     protected _monitoring: Browserless['monitoring'],
     protected _staticSDKDir: Browserless['staticSDKDir'],
@@ -163,14 +163,6 @@ abstract class Route {
    * @returns Config
    */
   config = () => this._config;
-
-  /**
-   * Helper function that loads the debug module, useful
-   * for logging messages scoped to the routes path. Defined
-   * and injected by browserless after initialization.
-   * @returns Debug
-   */
-  debug = () => this._debug;
 
   /**
    * Helper function that loads the file-system module
@@ -254,6 +246,7 @@ export abstract class HTTPRoute extends BasicHTTPRoute {
   abstract handler: (
     req: Request,
     res: http.ServerResponse,
+    logger: Logger,
   ) => Promise<unknown>;
 }
 
@@ -274,6 +267,7 @@ export abstract class BrowserHTTPRoute extends BasicHTTPRoute {
   abstract handler: (
     req: Request,
     res: http.ServerResponse,
+    logger: Logger,
     browser: BrowserInstance,
   ) => Promise<unknown>;
 
@@ -298,6 +292,7 @@ export abstract class WebSocketRoute extends Route {
     req: Request,
     socket: stream.Duplex,
     head: Buffer,
+    logger: Logger,
   ) => Promise<unknown>;
 }
 
@@ -319,6 +314,7 @@ export abstract class BrowserWebsocketRoute extends Route {
     req: Request,
     socket: stream.Duplex,
     head: Buffer,
+    logger: Logger,
     browser: BrowserInstance,
   ): Promise<unknown>;
 


### PR DESCRIPTION
<img width="1595" alt="Screenshot 2024-04-11 at 12 35 21 PM" src="https://github.com/browserless/browserless/assets/1499985/9258a527-b12c-459a-814b-f300793e3cf8">

New `Logger` class suitable for capture custom logs in route handlers. This does change the API of the SDK and Handlers such that `handler`'s now have an additional argument of `log`:

```js
/**
 * Handles an inbound Websocket request, and handles the connection
 * with the prior set browser being injected.
 */
abstract handler(
  req: Request,
  socket: stream.Duplex,
  head: Buffer,
  logger: Logger,
  browser: BrowserInstance,
): Promise<unknown>;
```

Today, the default logging class captures the IP address of the underlying request, but it can be used to capture other characteristics of the request.