### PR TITLE
feat: Browser hook updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # [Latest](https://github.com/browserless/chrome/compare/v2.12.0...main)
+**Potentially Breaking**
+- The `browser` hook now gets the `req` property for the full request instead of `meta`.
 - Dependency updates.
 
 # [v2.12.0](https://github.com/browserless/chrome/compare/v2.11.0...v2.12.0)

--- a/bin/scaffold/README.md
+++ b/bin/scaffold/README.md
@@ -175,10 +175,10 @@ export default class HelloWorldRoute extends HTTPRoute {
   // Handler is a function, getting the request and response objects, and is where you'll write the
   // core logic behind this route. Use utilities like writeResponse or writeJSONResponse to help
   // return the appropriate response.
-  async handler (_req, res, _logger: Logger): Promise<void> {
+  async handler(_req, res, _logger: Logger): Promise<void> {
     const response: ResponseSchema = 'Hello World!';
     return writeResponse(res, 200, ResponseSchema, contentTypes.text);
-  };
+  }
 }
 ```
 
@@ -228,7 +228,7 @@ export default class ChromiumWebSocketRoute extends BrowserWebsocketRoute {
   // Routes with a browser type get a browser argument of the Browser instance, otherwise
   // request, socket, and head are the other 3 arguments. Here we pass them through
   // and proxy the request into Chromium to handle.
-  async handler (req, socket, head, logger, chromium): Promise<void> {
+  async handler(req, socket, head, logger, chromium): Promise<void> {
     return chromium.proxyWebSocket(req, socket, head);
   }
 }
@@ -288,7 +288,7 @@ export default class MyConfig extends Config {
   public getS3Bucket(): string {
     // Load from environment variables or default to some other named bucket.
     return process.env.S3_BUCKET ?? 'my-fun-s3-bucket';
-  };
+  }
 }
 ```
 
@@ -345,7 +345,7 @@ export default class PDFToS3Route extends BrowserHTTPRoute {
   tags = [APITags.browserAPI];
 
   // Handler's are where we embed the logic that facilitates this route.
-  async handler (req, res, logger, browser): Promise<void> {
+  async handler(req, res, logger, browser): Promise<void> {
     // Modules like Config are injected via this internal methods.
     // Use them to load core modules within the platform.
     const config = this.config() as MyConfig;
@@ -353,7 +353,7 @@ export default class PDFToS3Route extends BrowserHTTPRoute {
     const page = await browser.newPage();
 
     // ...Handle the rest!
-  };
+  }
 }
 ```
 

--- a/bin/scaffold/src/hello-world.http.ts
+++ b/bin/scaffold/src/hello-world.http.ts
@@ -22,11 +22,7 @@ export default class HelloWorldHTTPRoute extends HTTPRoute {
   method = Methods.get;
   path = '/hello';
   tags = [APITags.management];
-  async handler (
-    req: Request,
-    res: Response,
-    logger: Logger,
-  ): Promise<void> {
+  async handler(req: Request, res: Response, logger: Logger): Promise<void> {
     logger.verbose(`${req.method} /hello was called!`);
     const response: ResponseSchema = 'Hello World!';
     return writeResponse(res, 200, response, contentTypes.text);

--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -532,7 +532,7 @@ export class BrowserManager {
     const pwVersion = match ? match[1] : 'default';
 
     await browser.launch(launchOptions as object, pwVersion);
-    await this.hooks.browser({ browser, meta: req.parsed });
+    await this.hooks.browser({ browser, req });
 
     const session: BrowserlessSession = {
       id: browser.wsEndpoint()?.split('/').pop() as string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,7 @@ export interface BrowserHook {
     | ChromiumPlaywright
     | FirefoxPlaywright
     | WebkitPlaywright;
-  meta: URL;
+  req: Request;
 }
 
 export interface PageHook {


### PR DESCRIPTION
Instead of just passing the parsed request object as `meta` in browser hooks, let's opt for a more symmetrical API with `req` as the `Request` object instead.