### PR TITLE
avoid removing all jobs from limiter on error

### DIFF
--- a/src/limiter.spec.ts
+++ b/src/limiter.spec.ts
@@ -135,7 +135,7 @@ describe(`Limiter`, () => {
     const job = limiter.limit(spy, asyncNoop, asyncNoop, noop);
     await job().catch(noop);
 
-    limiter.addEventListener('end', (res) => {
+    limiter.addEventListener('error', (res) => {
       // 'end' callback fires before the failed callback hooks do, so nextTick to wait
       process.nextTick(() => {
         expect(res.detail.error).to.eql(error);

--- a/src/limiter.ts
+++ b/src/limiter.ts
@@ -72,7 +72,7 @@ export class Limiter extends q {
 
     this.addEventListener('end', this.handleEnd.bind(this));
   }
-  
+
   protected _errorHandler({
     detail: { error },
   }: {

--- a/src/limiter.ts
+++ b/src/limiter.ts
@@ -72,6 +72,14 @@ export class Limiter extends q {
 
     this.addEventListener('end', this.handleEnd.bind(this));
   }
+  
+  protected _errorHandler({
+    detail: { error },
+  }: {
+    detail: { error: unknown };
+  }) {
+    this.logger.error(error);
+  }
 
   protected handleEnd() {
     this.logQueue('All jobs complete.');


### PR DESCRIPTION
overwrite [_errorHandler method ](https://github.com/jessetane/queue/blob/master/index.js#L31) to avoid ending the queue when a job fails.
