### PR TITLE
JPEG screenshots returning wrong mimetype

### DIFF
--- a/.github/workflows/docker-chrome.yml
+++ b/.github/workflows/docker-chrome.yml
@@ -1,6 +1,6 @@
 name: Chrome
 
-on: [pull_request]
+on: [push]
 
 jobs:
   Test:

--- a/.github/workflows/docker-chromium.yml
+++ b/.github/workflows/docker-chromium.yml
@@ -1,6 +1,6 @@
 name: Chromium
 
-on: [pull_request]
+on: [push]
 
 jobs:
   Test:

--- a/src/routes/chrome/tests/screenshot.spec.ts
+++ b/src/routes/chrome/tests/screenshot.spec.ts
@@ -122,6 +122,30 @@ describe('/chrome/screenshot API', function () {
     });
   });
 
+  it('allows setting jpg type', async () => {
+    const config = new Config();
+    config.setToken('browserless');
+    const metrics = new Metrics();
+    await start({ config, metrics });
+    const body = {
+      url: 'https://example.com',
+      options: {
+        type: 'jpeg',
+      },
+    };
+
+    await fetch('http://localhost:3000/chrome/screenshot?token=browserless', {
+      body: JSON.stringify(body),
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    }).then((res) => {
+      expect(res.headers.get('content-type')).to.equal('image/jpeg');
+      expect(res.status).to.equal(200);
+    });
+  });
+
   it('allows for providing http response payloads', async () => {
     const config = new Config();
     const metrics = new Metrics();

--- a/src/routes/chromium/tests/screenshot.spec.ts
+++ b/src/routes/chromium/tests/screenshot.spec.ts
@@ -122,6 +122,30 @@ describe('/chromium/screenshot API', function () {
     });
   });
 
+  it('allows setting jpg type', async () => {
+    const config = new Config();
+    config.setToken('browserless');
+    const metrics = new Metrics();
+    await start({ config, metrics });
+    const body = {
+      url: 'https://example.com',
+      options: {
+        type: 'jpeg',
+      },
+    };
+
+    await fetch('http://localhost:3000/chromium/screenshot?token=browserless', {
+      body: JSON.stringify(body),
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    }).then((res) => {
+      expect(res.headers.get('content-type')).to.equal('image/jpeg');
+      expect(res.status).to.equal(200);
+    });
+  });
+  
   it('allows for providing http response payloads', async () => {
     const config = new Config();
     const metrics = new Metrics();


### PR DESCRIPTION
I'm writing a simple HTTP API wrapper in ruby for the browserless docker image, and I've found that jpeg screenshots return the wrong mimetype (png). I'm not familiar with the codebase, so I started by checking the specs and couldn't find any tests for generating jpegs with the screenshot endpoint. Before diving deeper I wanted to first add a test – which I'm assuming will fail.