### PR TITLE
Introducing Browserless Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![Firefox CI](https://github.com/browserless/chrome/actions/workflows/docker-firefox.yml/badge.svg)
 ![Webkit CI](https://github.com/browserless/chrome/actions/workflows/docker-webkit.yml/badge.svg)
 ![Multi CI](https://github.com/browserless/chrome/actions/workflows/docker-multi.yml/badge.svg)
-![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Browserless%20Guru-006BFF)](https://gurubase.io/g/browserless)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Browserless%20Guru-006BFF)](https://gurubase.io/g/browserless)
 
 > [!NOTE]  
 > [Looking for v1.x.x of browserless? You can find it here](https://github.com/browserless/chrome/tree/v1), although we recommend [migrating](/MIGRATION-2.0.md) to v2.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ![Firefox CI](https://github.com/browserless/chrome/actions/workflows/docker-firefox.yml/badge.svg)
 ![Webkit CI](https://github.com/browserless/chrome/actions/workflows/docker-webkit.yml/badge.svg)
 ![Multi CI](https://github.com/browserless/chrome/actions/workflows/docker-multi.yml/badge.svg)
+![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Browserless%20Guru-006BFF)](https://gurubase.io/g/browserless)
 
 > [!NOTE]  
 > [Looking for v1.x.x of browserless? You can find it here](https://github.com/browserless/chrome/tree/v1), although we recommend [migrating](/MIGRATION-2.0.md) to v2.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Browserless Guru](https://gurubase.io/g/browserless) to Gurubase. Browserless Guru uses the data from this repo and data from the [docs](https://docs.browserless.io/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Browserless Guru", which highlights that Browserless now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Browserless Guru in Gurubase, just let me know that's totally fine.
