### PR TITLE
build: bump ubuntu

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.source https://github.com/browserless/browserless
 

--- a/docker/multi/Dockerfile
+++ b/docker/multi/Dockerfile
@@ -25,7 +25,8 @@ RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula sele
     fonts-thai-tlwg \
     fonts-ubuntu \
     fonts-wqy-zenhei \
-    fonts-open-sans
+    fonts-open-sans \
+    libwebp-dev
 
 # Chrome stable is only supported on non-ARM builds
 # so it's installation is conditional on whether or not amd64

--- a/docker/webkit/Dockerfile
+++ b/docker/webkit/Dockerfile
@@ -25,7 +25,8 @@ RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula sele
     fonts-roboto \
     fonts-thai-tlwg \
     fonts-ubuntu \
-    fonts-wqy-zenhei
+    fonts-wqy-zenhei \
+    libwebp-dev
 
 # NOTE it's important to not use npx playwright-core here since it'll likely install
 # a more recent version than we potentially have in our own package.json


### PR DESCRIPTION
Playwright informed that `There will be no more updates for WebKit on Ubuntu 20.04 and Debian 11` https://github.com/microsoft/playwright/releases/tag/v1.49.0