### PR TITLE
fix: add headers to debug network info

### DIFF
--- a/src/shared/scrape.http.ts
+++ b/src/shared/scrape.http.ts
@@ -282,7 +282,7 @@ export default class ChromiumScrapePostRoute extends BrowserHTTPRoute {
 
       page.on('request', (req) => {
         outbound.push({
-          headers: req.headers,
+          headers: req.headers(),
           method: req.method(),
           url: req.url(),
         });
@@ -291,7 +291,7 @@ export default class ChromiumScrapePostRoute extends BrowserHTTPRoute {
 
       page.on('response', (res) => {
         inbound.push({
-          headers: res.headers,
+          headers: res.headers(),
           status: res.status(),
           url: res.url(),
         });


### PR DESCRIPTION
As reported in issue #3866 the header property in network on a scrape call did not get filled. This pull request fixes this.