### PR TITLE
Make sure GET /sessions always returns properly formatted URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     ],
     "loader": "ts-node/esm",
     "spec": "src/**/*.spec.ts",
-    "timeout": 30000,
+    "timeout": 45000,
     "slow": 5000
   },
   "prettier": {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -17,4 +17,4 @@ then
 fi
 
 # Run the tests
-./node_modules/.bin/_mocha --timeout 30000 --slow 10000 --exit $@ && kill -TERM $xvfb
+./node_modules/.bin/_mocha --timeout 45000 --slow 10000 --exit $@ && kill -TERM $xvfb

--- a/src/limiter.spec.ts
+++ b/src/limiter.spec.ts
@@ -65,7 +65,7 @@ describe(`Limiter`, () => {
         resolve(undefined);
       });
     });
-  }).timeout(5000);
+  });
 
   it('passes through arguments', () =>
     new Promise((resolve, reject) => {

--- a/src/routes/chrome/tests/kill-sessions.spec.ts
+++ b/src/routes/chrome/tests/kill-sessions.spec.ts
@@ -47,7 +47,7 @@ describe('/kill API', function () {
     }
     expect((errorThrown1 as Error).message).contains('closed');
     expect((errorThrown2 as Error).message).contains('closed');
-  }).timeout(45000);
+  });
 
   it('Kill session by browserId', async () => {
     await start();

--- a/src/routes/chrome/tests/page-websocket.spec.ts
+++ b/src/routes/chrome/tests/page-websocket.spec.ts
@@ -4,10 +4,6 @@ import { NodeWebSocketTransport } from 'puppeteer-core/lib/esm/puppeteer/node/No
 import { expect } from 'chai';
 
 describe('WebSocket Page API', function () {
-  // Server shutdown can take a few seconds
-  // and so can these tests :/
-  this.timeout(5000);
-
   let browserless: Browserless;
 
   const start = ({

--- a/src/routes/chromium/tests/kill-sessions.spec.ts
+++ b/src/routes/chromium/tests/kill-sessions.spec.ts
@@ -47,7 +47,7 @@ describe('/kill API', function () {
     }
     expect((errorThrown1 as Error).message).contains('closed');
     expect((errorThrown2 as Error).message).contains('closed');
-  }).timeout(45000);
+  });
 
   it('Kill session by browserId', async () => {
     await start();

--- a/src/routes/chromium/tests/page-websocket.spec.ts
+++ b/src/routes/chromium/tests/page-websocket.spec.ts
@@ -4,10 +4,6 @@ import { NodeWebSocketTransport } from 'puppeteer-core/lib/esm/puppeteer/node/No
 import { expect } from 'chai';
 
 describe('WebSocket Page API', function () {
-  // Server shutdown can take a few seconds
-  // and so can these tests :/
-  this.timeout(5000);
-
   let browserless: Browserless;
 
   const start = ({

--- a/src/routes/chromium/tests/websocket.spec.ts
+++ b/src/routes/chromium/tests/websocket.spec.ts
@@ -13,10 +13,6 @@ import { expect } from 'chai';
 import puppeteer from 'puppeteer-core';
 
 describe('Chromium WebSocket API', function () {
-  // Server shutdown can take a few seconds
-  // and so can these tests :/
-  this.timeout(5000);
-
   let browserless: Browserless;
 
   const start = ({

--- a/src/routes/edge/tests/page-websocket.spec.ts
+++ b/src/routes/edge/tests/page-websocket.spec.ts
@@ -4,10 +4,6 @@ import { NodeWebSocketTransport } from 'puppeteer-core/lib/esm/puppeteer/node/No
 import { expect } from 'chai';
 
 describe('WebSocket Page API', function () {
-  // Server shutdown can take a few seconds
-  // and so can these tests :/
-  this.timeout(5000);
-
   let browserless: Browserless;
 
   const start = ({

--- a/src/routes/firefox/tests/kill-sessions.spec.ts
+++ b/src/routes/firefox/tests/kill-sessions.spec.ts
@@ -47,7 +47,7 @@ describe('/kill API firefox', function () {
     }
     expect((errorThrown1 as Error).message).contains('closed');
     expect((errorThrown2 as Error).message).contains('closed');
-  }).timeout(45000);
+  });
 
   it('Kill session by browserId', async () => {
     await start();

--- a/src/routes/webkit/tests/kill-sessions.spec.ts
+++ b/src/routes/webkit/tests/kill-sessions.spec.ts
@@ -47,7 +47,7 @@ describe('/kill API webkit', function () {
     }
     expect((errorThrown1 as Error).message).contains('closed');
     expect((errorThrown2 as Error).message).contains('closed');
-  }).timeout(45000);
+  });
 
   it('Kill session by browserId', async () => {
     await start();

--- a/src/routes/webkit/tests/websocket.spec.ts
+++ b/src/routes/webkit/tests/websocket.spec.ts
@@ -8,10 +8,6 @@ import { expect } from 'chai';
 import { webkit } from 'playwright-core';
 
 describe('Webkit Websocket API', function () {
-  // Server shutdown can take a few seconds
-  // and so can these tests :/
-  this.timeout(5000);
-
   let browserless: Browserless;
 
   const start = ({


### PR DESCRIPTION
This ensure the /sessions API returns properly formatted URLs when an `-e EXTERNAL` variable is provided