### PR TITLE
fix: adblock, by switching to uBlock Lite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 node_modules/
 build/
 metrics.json
-extensions/ublock
+extensions/ublocklite
 
 # npm pack
 browserless.io-browserless-*.tgz

--- a/scripts/install-adblock.js
+++ b/scripts/install-adblock.js
@@ -2,7 +2,7 @@
 /* global fetch, console, process */
 'use strict';
 
-import { createWriteStream, existsSync } from 'fs';
+import { createWriteStream, existsSync, mkdirSync } from 'fs';
 import path, { join } from 'path';
 import { Readable } from 'stream';
 import { deleteAsync } from 'del';
@@ -11,10 +11,17 @@ import os from 'os';
 import unzip from 'extract-zip';
 
 (async () => {
-  const zipFile = os.tmpdir() + '/ublock.zip';
-  const tmpUblockPath = path.join(os.tmpdir(), 'uBlock0.chromium'); // uBlock0.chromium is always the prod name
+  const tmpDir = path.join(os.tmpdir(), '_ublite' + Date.now());
+  
+  // Create temporary directory if it doesn't exist
+  if (!existsSync(tmpDir)) {
+    mkdirSync(tmpDir, { recursive: true });
+  }
+  
+  const zipFile = tmpDir + '/ublock.zip';
+  const tmpUblockLitePath = path.join(tmpDir);
   const extensionsDir = join(process.cwd(), 'extensions');
-  const uBlockDir = join(extensionsDir, 'ublock');
+  const uBlockLiteDir = join(extensionsDir, 'ublocklite');
 
   const downloadUrlToDirectory = (url, dir) =>
     fetch(url).then(
@@ -28,17 +35,17 @@ import unzip from 'extract-zip';
         }),
     );
 
-  if (existsSync(uBlockDir)) {
-    await deleteAsync(uBlockDir);
+  if (existsSync(uBlockLiteDir)) {
+    await deleteAsync(uBlockLiteDir);
   }
   const data = await fetch(
-    'https://api.github.com/repos/gorhill/uBlock/releases/latest',
+    'https://api.github.com/repos/uBlockOrigin/uBOL-home/releases/latest',
   );
   const json = await data.json();
 
   await downloadUrlToDirectory(json.assets[0].browser_download_url, zipFile);
-  await unzip(zipFile, { dir: os.tmpdir() });
-  await moveFile(join(tmpUblockPath), join(extensionsDir, 'ublock'));
+  await unzip(zipFile, { dir: tmpDir });
+  await moveFile(join(tmpUblockLitePath), join(extensionsDir, 'ublocklite'));
   await deleteAsync(zipFile, { force: true }).catch((err) => {
     console.warn('Could not delete temporary download file: ' + err.message);
   });

--- a/src/browsers/browsers.cdp.ts
+++ b/src/browsers/browsers.cdp.ts
@@ -9,7 +9,7 @@ import {
   edgeExecutablePath,
   noop,
   once,
-  ublockPath,
+  ublockLitePath,
 } from '@browserless.io/browserless';
 import puppeteer, { Browser, Page, Target } from 'puppeteer-core';
 import { Duplex } from 'stream';
@@ -190,7 +190,7 @@ export class ChromiumCDP extends EventEmitter {
     );
 
     const extensions = [
-      this.blockAds ? ublockPath : null,
+      this.blockAds ? ublockLitePath : null,
       extensionLaunchArgs ? extensionLaunchArgs.split('=')[1] : null,
     ].filter((_) => !!_);
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -161,7 +161,7 @@ export type Response = http.ServerResponse;
 export interface SystemQueryParameters {
   /**
    * Whether or nor to load ad-blocking extensions for the session.
-   * This currently uses uBlock Origin and may cause certain sites
+   * This currently uses uBlock-Lite and may cause certain sites
    * to not load properly.
    */
   blockAds?: boolean;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -880,4 +880,4 @@ export const getCDPClient = (page: Page): CDPSession => {
   return typeof c === 'function' ? c.call(page) : c;
 };
 
-export const ublockPath = path.join(__dirname, '..', 'extensions', 'ublock');
+export const ublockLitePath = path.join(__dirname, '..', 'extensions', 'ublocklite');


### PR DESCRIPTION
Chrome automatically disabled uBlock Origin since it doesn't use Manifest v3. This PR switches uBlock Origin for uBlock Lite, which is manifest v3 and works for every purpose that we need adblock in the project for.

![image](https://github.com/user-attachments/assets/46cb7699-b8d8-43ec-a424-d7be38b1939f)
