### PR TITLE
feat: Add support for IPv6 listener

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -481,7 +481,7 @@ export class Config extends EventEmitter {
    * @returns Fully-qualified server address
    */
   public getServerAddress(): string {
-    const host = this.host === '::' ? '0.0.0.0' : this.host;
+    const host = this.host === '::' ? 'localhost' : this.host;
 
     return this.port === 443
       ? `https://${host}:${this.port}`

--- a/src/config.ts
+++ b/src/config.ts
@@ -481,11 +481,13 @@ export class Config extends EventEmitter {
    * @returns Fully-qualified server address
    */
   public getServerAddress(): string {
+    const host = this.host === '::' ? '0.0.0.0' : this.host;
+
     return this.port === 443
-      ? `https://${this.host}:${this.port}`
+      ? `https://${host}:${this.port}`
       : this.port === 80
-        ? `http://${this.host}`
-        : `http://${this.host}:${this.port}`;
+        ? `http://${host}`
+        : `http://${host}:${this.port}`;
   }
 
   /**


### PR DESCRIPTION
Add support for IPv6 listener (`::`), its currently failing due to `getServerAddress`, the returned URL will be invalid while using host `::`.

Fixes #4509