### PR TITLE
worker based downloading directly of files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "debug": "^4.4.0",
         "del": "^8.0.0",
         "enjoi": "^9.0.1",
-        "eslint": "^9.24.0",
         "file-type": "^20.4.1",
         "get-port": "^7.1.0",
         "gradient-string": "^3.0.0",

--- a/src/http.ts
+++ b/src/http.ts
@@ -103,8 +103,9 @@ export enum HTTPRoutes {
   chromeFunction = '/chrome/function?(/)',
   chromePdf = '/chrome/pdf?(/)',
   chromePerformance = '/chrome/performance?(/)',
-  chromeScrape = '/chrome/scrape?(/)',
+  chromeScrape = '/scrape?(/)',
   chromeScreenshot = '/chrome/screenshot?(/)',
+  chromeSiteDownload = '/chrome/site-download?(/)',
   edgeContent = '/edge/content?(/)',
   edgeDownload = '/edge/download?(/)',
   edgeFunction = '/edge/function?(/)',
@@ -112,6 +113,7 @@ export enum HTTPRoutes {
   edgePerformance = '/edge/performance?(/)',
   edgeScrape = '/edge/scrape?(/)',
   edgeScreenshot = '/edge/screenshot?(/)',
+  edgeSiteDownload = '/edge/site-download?(/)',
   chromiumContent = '/chromium/content?(/)',
   chromiumDownload = '/chromium/download?(/)',
   chromiumFunction = '/chromium/function?(/)',
@@ -119,6 +121,7 @@ export enum HTTPRoutes {
   chromiumPerformance = '/chromium/performance?(/)',
   chromiumScrape = '/chromium/scrape?(/)',
   chromiumScreenshot = '/chromium/screenshot?(/)',
+  chromiumSiteDownload = '/chromium/site-download?(/)',
   content = '/content?(/)',
   download = '/download?(/)',
   function = '/function?(/)',
@@ -130,6 +133,7 @@ export enum HTTPRoutes {
   performance = '/performance?(/)',
   scrape = '/scrape?(/)',
   screenshot = '/screenshot?(/)',
+  siteDownload = '/site-download?(/)',
 }
 
 export enum HTTPManagementRoutes {

--- a/src/routes/chrome/http/site-download.post.ts
+++ b/src/routes/chrome/http/site-download.post.ts
@@ -1,0 +1,12 @@
+import { 
+  HTTPRoutes, 
+  ChromeCDP,
+  BrowserlessRoutes,
+} from '@browserless.io/browserless';
+import { default as ChromiumSiteDownloadPostRoute } from '../../../shared/site-download.http.js';
+
+export default class ChromeSiteDownloadPostRoute extends ChromiumSiteDownloadPostRoute {
+  name = BrowserlessRoutes.ChromeSiteDownloadPostRoute;
+  browser = ChromeCDP;
+  path = [HTTPRoutes.siteDownload, HTTPRoutes.chromeSiteDownload];
+} 

--- a/src/routes/chrome/tests/site-download.spec.ts
+++ b/src/routes/chrome/tests/site-download.spec.ts
@@ -1,0 +1,390 @@
+import { Browserless, Config, Metrics, sleep } from '@browserless.io/browserless';
+import { expect } from 'chai';
+
+describe('/chrome/site-download API', function () {
+  let browserless: Browserless;
+
+  const start = ({
+    config = new Config(),
+    metrics = new Metrics(),
+  }: { config?: Config; metrics?: Metrics } = {}) => {
+    browserless = new Browserless({ config, metrics });
+    return browserless.start();
+  };
+
+  afterEach(async () => {
+    await browserless.stop();
+  });
+
+  describe('Basic functionality', () => {
+    it('allows basic download requests', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+      };
+
+      await fetch('http://localhost:3000/chrome/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.headers.get('content-type')).to.include('text/html');
+        expect(res.headers.get('x-original-url')).to.equal('https://example.com');
+        expect(res.headers.get('x-response-code')).to.equal('200');
+        expect(res.headers.get('x-content-type')).to.include('text/html');
+        expect(res.status).to.equal(200);
+      });
+    });
+
+    it('404s GET requests', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+
+      await fetch('http://localhost:3000/chrome/site-download?token=browserless').then((res) => {
+        expect(res.status).to.equal(404);
+      });
+    });
+
+    it('allows requests without token when auth token is not set', async () => {
+      await start();
+      const body = {
+        url: 'https://example.com',
+      };
+
+      await fetch('http://localhost:3000/chrome/site-download', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(200);
+        expect(res.headers.get('content-type')).to.include('text/html');
+      });
+    });
+
+    it('rejects requests with invalid token', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+      };
+
+      await fetch('http://localhost:3000/chrome/site-download?token=invalid', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(401);
+      });
+    });
+  });
+
+  describe('Request options', () => {
+    it('allows requests with custom headers and cookies', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        headers: {
+          'User-Agent': 'Custom User Agent',
+          'Accept-Language': 'en-US',
+        },
+        cookies: [{
+          name: 'test-cookie',
+          value: 'test-value',
+          domain: 'example.com',
+        }],
+      };
+
+      await fetch('http://localhost:3000/chrome/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(200);
+        expect(res.headers.get('content-type')).to.include('text/html');
+      });
+    });
+
+    it('allows requests with goto options and wait selectors', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        gotoOptions: {
+          waitUntil: 'networkidle0',
+          timeout: 30000,
+        },
+        waitForSelector: {
+          selector: 'h1',
+          timeout: 5000,
+        },
+      };
+
+      await fetch('http://localhost:3000/chrome/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(200);
+      });
+    });
+
+    it('handles viewport settings', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        viewport: {
+          width: 1920,
+          height: 1080,
+          deviceScaleFactor: 2,
+        },
+      };
+
+      await fetch('http://localhost:3000/chrome/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(200);
+      });
+    });
+
+    it('handles custom user agent', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        userAgent: 'Custom User Agent String',
+      };
+
+      await fetch('http://localhost:3000/chrome/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(200);
+      });
+    });
+  });
+
+  describe('Session handling', () => {
+    it('handles existing session downloads', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        useExistingSession: true,
+      };
+
+      await fetch('http://localhost:3000/chrome/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(200);
+        expect(res.headers.get('content-type')).to.include('text/html');
+      });
+    });
+
+    it('includes session ID in response headers when provided', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        useExistingSession: true,
+        sessionId: 'test-session',
+      };
+
+      await fetch('http://localhost:3000/chrome/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(200);
+        expect(res.headers.get('x-session-id')).to.equal('test-session');
+      });
+    });
+  });
+
+  describe('Error handling', () => {
+    it('handles errors for invalid URLs', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'not-a-valid-url',
+      };
+
+      await fetch('http://localhost:3000/chrome/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(500);
+      });
+    });
+
+    it('handles missing URL parameter', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {};
+
+      await fetch('http://localhost:3000/chrome/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(400);
+      });
+    });
+
+    it('handles invalid waitForSelector timeout', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        waitForSelector: {
+          selector: '#non-existent',
+          timeout: 1, // Very short timeout to trigger error
+        },
+      };
+
+      await fetch('http://localhost:3000/chrome/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(500);
+      });
+    });
+
+    it('handles malformed JSON body', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+
+      await fetch('http://localhost:3000/chrome/site-download?token=browserless', {
+        body: 'not-json',
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(400);
+      });
+    });
+  });
+
+  describe('Request cancellation', () => {
+    it('cancels request when they are closed early', async () => {
+      const config = new Config();
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+      };
+      const controller = new AbortController();
+      const signal = controller.signal;
+      const promise = fetch('http://localhost:3000/chrome/site-download', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+        signal,
+      }).catch(async (error) => {
+        await sleep(100);
+        expect(error).to.have.property('name', 'AbortError');
+        expect(metrics.get().error).to.equal(1);
+        expect(metrics.get().successful).to.equal(0);
+      });
+      await sleep(1000);
+      controller.abort();
+      return promise;
+    });
+
+    it('cleans up resources after cancellation', async () => {
+      const config = new Config();
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        useExistingSession: true,
+      };
+      const controller = new AbortController();
+      const signal = controller.signal;
+      
+      const promise = fetch('http://localhost:3000/chrome/site-download', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+        signal,
+      }).catch(async (error) => {
+        await sleep(100);
+        expect(error).to.have.property('name', 'AbortError');
+        // Verify metrics show proper cleanup
+        const currentMetrics = metrics.get();
+        expect(currentMetrics.error).to.equal(1);
+        expect(currentMetrics.successful).to.equal(0);
+        expect(currentMetrics.timedout).to.equal(0);
+        expect(currentMetrics.rejected).to.equal(0);
+      });
+      
+      await sleep(1000);
+      controller.abort();
+      return promise;
+    });
+  });
+}); 

--- a/src/routes/chromium/http/site-download.post.ts
+++ b/src/routes/chromium/http/site-download.post.ts
@@ -1,0 +1,12 @@
+import { 
+  HTTPRoutes, 
+  ChromiumCDP,
+  BrowserlessRoutes,
+} from '@browserless.io/browserless';
+import { default as BaseChromiumSiteDownloadPostRoute } from '../../../shared/site-download.http.js';
+
+export default class ChromiumSiteDownloadPostRoute extends BaseChromiumSiteDownloadPostRoute {
+  name = BrowserlessRoutes.ChromiumSiteDownloadPostRoute;
+  browser = ChromiumCDP;
+  path = [HTTPRoutes.siteDownload, HTTPRoutes.chromiumSiteDownload];
+} 

--- a/src/routes/chromium/tests/site-download.spec.ts
+++ b/src/routes/chromium/tests/site-download.spec.ts
@@ -1,0 +1,390 @@
+import { Browserless, Config, Metrics, sleep } from '@browserless.io/browserless';
+import { expect } from 'chai';
+
+describe('/chromium/site-download API', function () {
+  let browserless: Browserless;
+
+  const start = ({
+    config = new Config(),
+    metrics = new Metrics(),
+  }: { config?: Config; metrics?: Metrics } = {}) => {
+    browserless = new Browserless({ config, metrics });
+    return browserless.start();
+  };
+
+  afterEach(async () => {
+    await browserless.stop();
+  });
+
+  describe('Basic functionality', () => {
+    it('allows basic download requests', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+      };
+
+      await fetch('http://localhost:3000/chromium/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.headers.get('content-type')).to.include('text/html');
+        expect(res.headers.get('x-original-url')).to.equal('https://example.com');
+        expect(res.headers.get('x-response-code')).to.equal('200');
+        expect(res.headers.get('x-content-type')).to.include('text/html');
+        expect(res.status).to.equal(200);
+      });
+    });
+
+    it('404s GET requests', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+
+      await fetch('http://localhost:3000/chromium/site-download?token=browserless').then((res) => {
+        expect(res.status).to.equal(404);
+      });
+    });
+
+    it('allows requests without token when auth token is not set', async () => {
+      await start();
+      const body = {
+        url: 'https://example.com',
+      };
+
+      await fetch('http://localhost:3000/chromium/site-download', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(200);
+        expect(res.headers.get('content-type')).to.include('text/html');
+      });
+    });
+
+    it('rejects requests with invalid token', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+      };
+
+      await fetch('http://localhost:3000/chromium/site-download?token=invalid', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(401);
+      });
+    });
+  });
+
+  describe('Request options', () => {
+    it('allows requests with custom headers and cookies', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        headers: {
+          'User-Agent': 'Custom User Agent',
+          'Accept-Language': 'en-US',
+        },
+        cookies: [{
+          name: 'test-cookie',
+          value: 'test-value',
+          domain: 'example.com',
+        }],
+      };
+
+      await fetch('http://localhost:3000/chromium/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(200);
+        expect(res.headers.get('content-type')).to.include('text/html');
+      });
+    });
+
+    it('allows requests with goto options and wait selectors', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        gotoOptions: {
+          waitUntil: 'networkidle0',
+          timeout: 30000,
+        },
+        waitForSelector: {
+          selector: 'h1',
+          timeout: 5000,
+        },
+      };
+
+      await fetch('http://localhost:3000/chromium/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(200);
+      });
+    });
+
+    it('handles viewport settings', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        viewport: {
+          width: 1920,
+          height: 1080,
+          deviceScaleFactor: 2,
+        },
+      };
+
+      await fetch('http://localhost:3000/chromium/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(200);
+      });
+    });
+
+    it('handles custom user agent', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        userAgent: 'Custom User Agent String',
+      };
+
+      await fetch('http://localhost:3000/chromium/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(200);
+      });
+    });
+  });
+
+  describe('Session handling', () => {
+    it('handles existing session downloads', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        useExistingSession: true,
+      };
+
+      await fetch('http://localhost:3000/chromium/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(200);
+        expect(res.headers.get('content-type')).to.include('text/html');
+      });
+    });
+
+    it('includes session ID in response headers when provided', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        useExistingSession: true,
+        sessionId: 'test-session',
+      };
+
+      await fetch('http://localhost:3000/chromium/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(200);
+        expect(res.headers.get('x-session-id')).to.equal('test-session');
+      });
+    });
+  });
+
+  describe('Error handling', () => {
+    it('handles errors for invalid URLs', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'not-a-valid-url',
+      };
+
+      await fetch('http://localhost:3000/chromium/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(500);
+      });
+    });
+
+    it('handles missing URL parameter', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {};
+
+      await fetch('http://localhost:3000/chromium/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(400);
+      });
+    });
+
+    it('handles invalid waitForSelector timeout', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        waitForSelector: {
+          selector: '#non-existent',
+          timeout: 1, // Very short timeout to trigger error
+        },
+      };
+
+      await fetch('http://localhost:3000/chromium/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(500);
+      });
+    });
+
+    it('handles malformed JSON body', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+
+      await fetch('http://localhost:3000/chromium/site-download?token=browserless', {
+        body: 'not-json',
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(400);
+      });
+    });
+  });
+
+  describe('Request cancellation', () => {
+    it('cancels request when they are closed early', async () => {
+      const config = new Config();
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+      };
+      const controller = new AbortController();
+      const signal = controller.signal;
+      const promise = fetch('http://localhost:3000/chromium/site-download', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+        signal,
+      }).catch(async (error) => {
+        await sleep(100);
+        expect(error).to.have.property('name', 'AbortError');
+        expect(metrics.get().error).to.equal(1);
+        expect(metrics.get().successful).to.equal(0);
+      });
+      await sleep(1000);
+      controller.abort();
+      return promise;
+    });
+
+    it('cleans up resources after cancellation', async () => {
+      const config = new Config();
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        useExistingSession: true,
+      };
+      const controller = new AbortController();
+      const signal = controller.signal;
+      
+      const promise = fetch('http://localhost:3000/chromium/site-download', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+        signal,
+      }).catch(async (error) => {
+        await sleep(100);
+        expect(error).to.have.property('name', 'AbortError');
+        // Verify metrics show proper cleanup
+        const currentMetrics = metrics.get();
+        expect(currentMetrics.error).to.equal(1);
+        expect(currentMetrics.successful).to.equal(0);
+        expect(currentMetrics.timedout).to.equal(0);
+        expect(currentMetrics.rejected).to.equal(0);
+      });
+      
+      await sleep(1000);
+      controller.abort();
+      return promise;
+    });
+  });
+}); 

--- a/src/routes/edge/http/site-download.post.ts
+++ b/src/routes/edge/http/site-download.post.ts
@@ -1,0 +1,12 @@
+import { 
+  HTTPRoutes, 
+  EdgeCDP,
+  BrowserlessRoutes,
+} from '@browserless.io/browserless';
+import { default as ChromiumSiteDownloadPostRoute } from '../../../shared/site-download.http.js';
+
+export default class EdgeSiteDownloadPostRoute extends ChromiumSiteDownloadPostRoute {
+  name = BrowserlessRoutes.EdgeSiteDownloadPostRoute;
+  browser = EdgeCDP;
+  path = [HTTPRoutes.siteDownload, HTTPRoutes.edgeSiteDownload];
+} 

--- a/src/routes/edge/tests/site-download.spec.ts
+++ b/src/routes/edge/tests/site-download.spec.ts
@@ -1,0 +1,390 @@
+import { Browserless, Config, Metrics, sleep } from '@browserless.io/browserless';
+import { expect } from 'chai';
+
+describe('/edge/site-download API', function () {
+  let browserless: Browserless;
+
+  const start = ({
+    config = new Config(),
+    metrics = new Metrics(),
+  }: { config?: Config; metrics?: Metrics } = {}) => {
+    browserless = new Browserless({ config, metrics });
+    return browserless.start();
+  };
+
+  afterEach(async () => {
+    await browserless.stop();
+  });
+
+  describe('Basic functionality', () => {
+    it('allows basic download requests', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+      };
+
+      await fetch('http://localhost:3000/edge/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.headers.get('content-type')).to.include('text/html');
+        expect(res.headers.get('x-original-url')).to.equal('https://example.com');
+        expect(res.headers.get('x-response-code')).to.equal('200');
+        expect(res.headers.get('x-content-type')).to.include('text/html');
+        expect(res.status).to.equal(200);
+      });
+    });
+
+    it('404s GET requests', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+
+      await fetch('http://localhost:3000/edge/site-download?token=browserless').then((res) => {
+        expect(res.status).to.equal(404);
+      });
+    });
+
+    it('allows requests without token when auth token is not set', async () => {
+      await start();
+      const body = {
+        url: 'https://example.com',
+      };
+
+      await fetch('http://localhost:3000/edge/site-download', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(200);
+        expect(res.headers.get('content-type')).to.include('text/html');
+      });
+    });
+
+    it('rejects requests with invalid token', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+      };
+
+      await fetch('http://localhost:3000/edge/site-download?token=invalid', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(401);
+      });
+    });
+  });
+
+  describe('Request options', () => {
+    it('allows requests with custom headers and cookies', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        headers: {
+          'User-Agent': 'Custom User Agent',
+          'Accept-Language': 'en-US',
+        },
+        cookies: [{
+          name: 'test-cookie',
+          value: 'test-value',
+          domain: 'example.com',
+        }],
+      };
+
+      await fetch('http://localhost:3000/edge/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(200);
+        expect(res.headers.get('content-type')).to.include('text/html');
+      });
+    });
+
+    it('allows requests with goto options and wait selectors', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        gotoOptions: {
+          waitUntil: 'networkidle0',
+          timeout: 30000,
+        },
+        waitForSelector: {
+          selector: 'h1',
+          timeout: 5000,
+        },
+      };
+
+      await fetch('http://localhost:3000/edge/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(200);
+      });
+    });
+
+    it('handles viewport settings', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        viewport: {
+          width: 1920,
+          height: 1080,
+          deviceScaleFactor: 2,
+        },
+      };
+
+      await fetch('http://localhost:3000/edge/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(200);
+      });
+    });
+
+    it('handles custom user agent', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        userAgent: 'Custom User Agent String',
+      };
+
+      await fetch('http://localhost:3000/edge/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(200);
+      });
+    });
+  });
+
+  describe('Session handling', () => {
+    it('handles existing session downloads', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        useExistingSession: true,
+      };
+
+      await fetch('http://localhost:3000/edge/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(200);
+        expect(res.headers.get('content-type')).to.include('text/html');
+      });
+    });
+
+    it('includes session ID in response headers when provided', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        useExistingSession: true,
+        sessionId: 'test-session',
+      };
+
+      await fetch('http://localhost:3000/edge/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(200);
+        expect(res.headers.get('x-session-id')).to.equal('test-session');
+      });
+    });
+  });
+
+  describe('Error handling', () => {
+    it('handles errors for invalid URLs', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'not-a-valid-url',
+      };
+
+      await fetch('http://localhost:3000/edge/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(500);
+      });
+    });
+
+    it('handles missing URL parameter', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {};
+
+      await fetch('http://localhost:3000/edge/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(400);
+      });
+    });
+
+    it('handles invalid waitForSelector timeout', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        waitForSelector: {
+          selector: '#non-existent',
+          timeout: 1, // Very short timeout to trigger error
+        },
+      };
+
+      await fetch('http://localhost:3000/edge/site-download?token=browserless', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(500);
+      });
+    });
+
+    it('handles malformed JSON body', async () => {
+      const config = new Config();
+      config.setToken('browserless');
+      const metrics = new Metrics();
+      await start({ config, metrics });
+
+      await fetch('http://localhost:3000/edge/site-download?token=browserless', {
+        body: 'not-json',
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }).then(async (res) => {
+        expect(res.status).to.equal(400);
+      });
+    });
+  });
+
+  describe('Request cancellation', () => {
+    it('cancels request when they are closed early', async () => {
+      const config = new Config();
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+      };
+      const controller = new AbortController();
+      const signal = controller.signal;
+      const promise = fetch('http://localhost:3000/edge/site-download', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+        signal,
+      }).catch(async (error) => {
+        await sleep(100);
+        expect(error).to.have.property('name', 'AbortError');
+        expect(metrics.get().error).to.equal(1);
+        expect(metrics.get().successful).to.equal(0);
+      });
+      await sleep(1000);
+      controller.abort();
+      return promise;
+    });
+
+    it('cleans up resources after cancellation', async () => {
+      const config = new Config();
+      const metrics = new Metrics();
+      await start({ config, metrics });
+      const body = {
+        url: 'https://example.com',
+        useExistingSession: true,
+      };
+      const controller = new AbortController();
+      const signal = controller.signal;
+      
+      const promise = fetch('http://localhost:3000/edge/site-download', {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+        signal,
+      }).catch(async (error) => {
+        await sleep(100);
+        expect(error).to.have.property('name', 'AbortError');
+        // Verify metrics show proper cleanup
+        const currentMetrics = metrics.get();
+        expect(currentMetrics.error).to.equal(1);
+        expect(currentMetrics.successful).to.equal(0);
+        expect(currentMetrics.timedout).to.equal(0);
+        expect(currentMetrics.rejected).to.equal(0);
+      });
+      
+      await sleep(1000);
+      controller.abort();
+      return promise;
+    });
+  });
+}); 

--- a/src/shared/site-download.http.ts
+++ b/src/shared/site-download.http.ts
@@ -1,0 +1,428 @@
+import {
+  APITags,
+  BadRequest,
+  BrowserHTTPRoute,
+  BrowserInstance,
+  BrowserlessRoutes,
+  ChromiumCDP,
+  HTTPRoutes,
+  Logger,
+  Methods,
+  Request,
+  contentTypes,
+  dedent,
+  SystemQueryParameters,
+  chromeExecutablePath,
+} from '@browserless.io/browserless';
+import { ServerResponse } from 'http';
+import { Readable } from 'stream';
+import { fork } from 'child_process';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { Page as PuppeteerPage, HTTPResponse } from 'puppeteer-core';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+type Page = PuppeteerPage & {
+  authenticate(credentials: { username: string; password: string }): Promise<void>;
+  setCookie(...cookies: Array<{ name: string; value: string; domain: string; path?: string }>): Promise<void>;
+  setUserAgent(userAgent: string): Promise<void>;
+  setViewport(viewport: { width: number; height: number; deviceScaleFactor?: number }): Promise<void>;
+};
+
+// Type definitions
+export type BodySchema = {
+  url: string;
+  cookies?: Array<{
+    name: string;
+    value: string;
+    domain?: string;
+    path?: string;
+    expires?: number;
+    httpOnly?: boolean;
+    secure?: boolean;
+    sameSite?: 'Strict' | 'Lax' | 'None';
+  }>;
+  headers?: Record<string, string>;
+  gotoOptions?: {
+    timeout?: number;
+    waitUntil?: 'load' | 'domcontentloaded' | 'networkidle0' | 'networkidle2';
+  };
+  waitForSelector?: {
+    selector: string;
+    timeout?: number;
+    visible?: boolean;
+    hidden?: boolean;
+  };
+  userAgent?: string;
+  viewport?: {
+    width: number;
+    height: number;
+    deviceScaleFactor?: number;
+  };
+  useExistingSession?: boolean;
+  sessionId?: string;
+};
+
+export type QuerySchema = SystemQueryParameters & {
+  token: string;
+};
+
+export type ResponseSchema = {
+  success: boolean;
+  error?: string;
+};
+
+// Schema validation objects
+export const BodySchema = {
+  type: 'object',
+  properties: {
+    url: {
+      type: 'string',
+      description: 'URL of the document to download',
+    },
+    cookies: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          value: { type: 'string' },
+          domain: { type: 'string' },
+          path: { type: 'string' },
+          expires: { type: 'number' },
+          httpOnly: { type: 'boolean' },
+          secure: { type: 'boolean' },
+          sameSite: { 
+            type: 'string',
+            enum: ['Strict', 'Lax', 'None']
+          },
+        },
+        required: ['name', 'value'],
+      },
+    },
+    headers: {
+      type: 'object',
+      additionalProperties: { type: 'string' }
+    },
+    gotoOptions: {
+      type: 'object',
+      properties: {
+        timeout: { type: 'number' },
+        waitUntil: {
+          type: 'string',
+          enum: ['load', 'domcontentloaded', 'networkidle0', 'networkidle2']
+        }
+      }
+    },
+    waitForSelector: {
+      type: 'object',
+      properties: {
+        selector: { type: 'string' },
+        timeout: { type: 'number' },
+        visible: { type: 'boolean' },
+        hidden: { type: 'boolean' }
+      },
+      required: ['selector']
+    },
+    userAgent: { type: 'string' },
+    viewport: {
+      type: 'object',
+      properties: {
+        width: { type: 'number' },
+        height: { type: 'number' },
+        deviceScaleFactor: { type: 'number' }
+      },
+      required: ['width', 'height']
+    },
+    useExistingSession: { type: 'boolean' },
+    sessionId: { type: 'string' }
+  },
+  required: ['url']
+} as const;
+
+export const QuerySchema = {
+  type: 'object',
+  properties: {
+    token: { type: 'string' }
+  },
+  required: ['token']
+} as const;
+
+export const ResponseSchema = {
+  type: 'object',
+  properties: {
+    success: { type: 'boolean' },
+    error: { type: 'string' }
+  },
+  required: ['success']
+} as const;
+
+export default class ChromiumSiteDownloadPostRoute extends BrowserHTTPRoute {
+  name = BrowserlessRoutes.ChromiumSiteDownloadPostRoute;
+  accepts = [contentTypes.json];
+  auth = true;
+  browser = ChromiumCDP;
+  concurrency = true;
+  contentTypes = [contentTypes.any];
+  description = dedent(`
+    A JSON-based API for downloading content from websites while maintaining security and privacy.
+    Content is streamed through memory without being stored on disk, ensuring no sensitive data
+    is retained. Supports custom headers, cookies, and wait conditions.
+    Downloads are processed in an isolated sandbox process for enhanced security.
+    Note: Authentication is not supported for security reasons - use cookies or headers instead.
+    
+    For existing browser sessions:
+    - Set useExistingSession: true to use the current browser session
+    - Optionally provide sessionId to use a specific session
+  `);
+  method = Methods.post;
+  path = [HTTPRoutes.siteDownload, HTTPRoutes.chromiumSiteDownload];
+  tags = [APITags.browserAPI];
+
+  private async handleExistingSession(
+    url: string,
+    options: Omit<BodySchema, 'url' | 'useExistingSession' | 'sessionId'>,
+    browser: BrowserInstance,
+    logger: Logger
+  ): Promise<{ stream: Readable; cleanup: () => Promise<void> }> {
+    // The browser instance is already the active session, so we can create a new page directly
+    const page = await browser.newPage() as unknown as Page;
+    
+    const outputStream = new Readable({
+      read() {} // We'll push data manually
+    });
+
+    try {
+      if (options.cookies?.length) {
+        await page.setCookie(...options.cookies);
+      }
+
+      if (options.headers && Object.keys(options.headers).length) {
+        await page.setExtraHTTPHeaders(options.headers);
+      }
+
+      if (options.userAgent) {
+        await page.setUserAgent(options.userAgent);
+      }
+
+      if (options.viewport) {
+        await page.setViewport(options.viewport);
+      }
+
+      const response = await page.goto(url, {
+        waitUntil: options.gotoOptions?.waitUntil || 'networkidle0',
+        ...options.gotoOptions,
+      }) as HTTPResponse;
+
+      if (!response) {
+        throw new Error(`Failed to get response from ${url}`);
+      }
+
+      if (options.waitForSelector) {
+        await page.waitForSelector(options.waitForSelector.selector, {
+          hidden: options.waitForSelector.hidden,
+          timeout: options.waitForSelector.timeout,
+          visible: options.waitForSelector.visible,
+        });
+      }
+
+      const contentType = response.headers()['content-type'];
+      const buffer = await response.buffer();
+
+      // Emit metadata
+      outputStream.emit('metadata', {
+        contentType,
+        contentLength: buffer.length,
+        status: response.status(),
+      });
+
+      // Stream the buffer in chunks
+      const chunkSize = 1024 * 1024; // 1MB chunks
+      for (let i = 0; i < buffer.length; i += chunkSize) {
+        const chunk = buffer.slice(i, i + chunkSize);
+        outputStream.push(chunk);
+      }
+
+      outputStream.push(null); // End the stream
+
+      return {
+        stream: outputStream,
+        cleanup: async () => {
+          try {
+            await page.close();
+          } catch (err) {
+            logger.error(`Error closing page: ${err}`);
+          }
+        }
+      };
+    } catch (error) {
+      await page.close().catch(err => logger.error(`Error closing page: ${err}`));
+      throw error;
+    }
+  }
+
+  private createSandboxedDownload(
+    url: string,
+    options: Omit<BodySchema, 'url' | 'useExistingSession' | 'sessionId'>,
+    logger: Logger
+  ): Promise<Readable> {
+    return new Promise((resolve, reject) => {
+      const outputStream = new Readable({
+        read() {} // We'll push data manually from the messages
+      });
+
+      // Create isolated process with memory limits
+      const sandboxProcess = fork(path.join(__dirname, '../workers/site-download.worker.js'), [], {
+        execArgv: ['--max-old-space-size=512'], // 512MB RAM limit
+      });
+
+      // Set up timeout handling
+      let timeoutId: NodeJS.Timeout;
+      const resetTimeout = () => {
+        if (timeoutId) clearTimeout(timeoutId);
+        timeoutId = setTimeout(() => {
+          outputStream.destroy(new Error('Download timeout'));
+          sandboxProcess.kill();
+        }, 30000); // 30 second timeout
+      };
+
+      resetTimeout();
+
+      // Get Chrome executable path
+      const executablePath = chromeExecutablePath();
+
+      // Send download request to child process
+      sandboxProcess.send({
+        type: 'download',
+        url,
+        executablePath,
+        options
+      });
+
+      // Handle messages from the child process
+      sandboxProcess.on('message', (message: any) => {
+        resetTimeout();
+
+        switch(message.type) {
+          case 'metadata':
+            outputStream.emit('metadata', {
+              contentType: message.contentType,
+              contentLength: message.contentLength,
+              status: message.status
+            });
+            break;
+
+          case 'data':
+            // Convert base64 back to Buffer and push to our stream
+            const chunk = Buffer.from(message.data, 'base64');
+            outputStream.push(chunk);
+            break;
+
+          case 'end':
+            // End of file has been reached
+            outputStream.push(null);
+            clearTimeout(timeoutId);
+            sandboxProcess.kill();
+            break;
+
+          case 'error':
+            // Error occurred in child process
+            const error = new Error(message.error);
+            outputStream.destroy(error);
+            sandboxProcess.kill();
+            break;
+        }
+      });
+
+      // Handle process errors
+      sandboxProcess.on('error', (error) => {
+        logger.error(`Sandbox process error: ${error}`);
+        outputStream.destroy(error);
+        clearTimeout(timeoutId);
+        reject(error);
+      });
+
+      // Handle process exit
+      sandboxProcess.on('exit', (code) => {
+        clearTimeout(timeoutId);
+        if (code !== 0 && !outputStream.destroyed) {
+          const error = new Error(`Download process exited with code ${code}`);
+          outputStream.destroy(error);
+          reject(error);
+        }
+      });
+
+      // Return the readable stream immediately
+      resolve(outputStream);
+    });
+  }
+
+  async handler(
+    req: Request,
+    res: ServerResponse,
+    logger: Logger,
+    browser: BrowserInstance,
+  ): Promise<void> {
+    logger.info(`Site download request received`, { url: (req.body as BodySchema)?.url });
+
+    if (!req.body || !(req.body as BodySchema).url) {
+      throw new BadRequest(`Missing "url" property in request body`);
+    }
+
+    const { url, useExistingSession, sessionId, ...options } = req.body as BodySchema;
+
+    try {
+      let downloadStream: Readable;
+      let cleanup: (() => Promise<void>) | undefined;
+
+      if (useExistingSession) {
+        const result = await this.handleExistingSession(url, options, browser, logger);
+        downloadStream = result.stream;
+        cleanup = result.cleanup;
+      } else {
+        downloadStream = await this.createSandboxedDownload(url, options, logger);
+      }
+
+      // Set up metadata handling
+      downloadStream.once('metadata', (metadata: { contentType: string; contentLength: number; status: number }) => {
+        res.setHeader('Content-Type', metadata.contentType);
+        res.setHeader('Content-Length', metadata.contentLength);
+        res.setHeader('X-Original-URL', url);
+        res.setHeader('X-Response-Code', metadata.status);
+        res.setHeader('X-Content-Type', metadata.contentType);
+        // Add additional headers for PDF handling
+        res.setHeader('Content-Disposition', 'attachment; filename="downloaded.pdf"');
+        res.setHeader('Content-Transfer-Encoding', 'binary');
+        res.setHeader('Accept-Ranges', 'bytes');
+        if (sessionId) {
+          res.setHeader('X-Session-ID', sessionId);
+        }
+      });
+
+      // Pipe the download stream to the response
+      downloadStream.pipe(res, { end: true });
+
+      // Handle errors
+      downloadStream.on('error', (error) => {
+        logger.error(`Error during download: ${error}`);
+        if (!res.headersSent) {
+          res.statusCode = 500;
+          res.end(`Download failed: ${error.message}`);
+        }
+      });
+
+      // Clean up when done
+      downloadStream.on('end', async () => {
+        if (cleanup) {
+          await cleanup();
+        }
+      });
+
+    } catch (error) {
+      logger.error(`Error initiating download: ${error}`);
+      throw error;
+    }
+  }
+} 

--- a/src/types.ts
+++ b/src/types.ts
@@ -630,6 +630,7 @@ export const BrowserlessChromeRoutes = {
   ChromePlaywrightWebSocketRoute: 'ChromePlaywrightWebSocketRoute',
   ChromeScrapePostRoute: 'ChromeScrapePostRoute',
   ChromeScreenshotPostRoute: 'ChromeScreenshotPostRoute',
+  ChromeSiteDownloadPostRoute: 'ChromeSiteDownloadPostRoute',
 };
 
 export const BrowserlessEdgeRoutes = {
@@ -648,6 +649,7 @@ export const BrowserlessEdgeRoutes = {
   EdgePlaywrightWebSocketRoute: 'EdgePlaywrightWebSocketRoute',
   EdgeScrapePostRoute: 'EdgeScrapePostRoute',
   EdgeScreenshotPostRoute: 'EdgeScreenshotPostRoute',
+  EdgeSiteDownloadPostRoute: 'EdgeSiteDownloadPostRoute',
 };
 
 export const BrowserlessChromiumRoutes = {
@@ -666,6 +668,7 @@ export const BrowserlessChromiumRoutes = {
   ChromiumPlaywrightWebSocketRoute: 'ChromiumPlaywrightWebSocketRoute',
   ChromiumScrapePostRoute: 'ChromiumScrapePostRoute',
   ChromiumScreenshotPostRoute: 'ChromiumScreenshotPostRoute',
+  ChromiumSiteDownloadPostRoute: 'ChromiumSiteDownloadPostRoute',
 };
 
 export const BrowserlessFirefoxRoutes = {

--- a/src/workers/site-download.worker.ts
+++ b/src/workers/site-download.worker.ts
@@ -1,0 +1,167 @@
+import puppeteer, { Browser } from 'puppeteer-core';
+
+interface DownloadMessage {
+  type: 'download';
+  url: string;
+  executablePath: string;
+  options: {
+    waitForSelector?: {
+      selector: string;
+      timeout?: number;
+      visible?: boolean;
+      hidden?: boolean;
+    };
+    cookies?: Array<{
+      name: string;
+      value: string;
+      domain: string;
+      path?: string;
+    }>;
+    headers?: Record<string, string>;
+    gotoOptions?: {
+      timeout?: number;
+      waitUntil?: 'load' | 'domcontentloaded' | 'networkidle0' | 'networkidle2';
+    };
+    userAgent?: string;
+    viewport?: {
+      width: number;
+      height: number;
+      deviceScaleFactor?: number;
+    };
+  };
+}
+
+let browser: Browser | null = null;
+
+// Handle cleanup on exit
+async function cleanup() {
+  if (browser) {
+    try {
+      await browser.close();
+    } catch (error) {
+      console.error('Error closing browser:', error);
+    }
+  }
+  process.exit(0);
+}
+
+process.on('SIGTERM', cleanup);
+process.on('SIGINT', cleanup);
+process.on('uncaughtException', async (error) => {
+  console.error('Uncaught exception:', error);
+  process.send?.({ type: 'error', error: error.message });
+  await cleanup();
+  process.exit(1);
+});
+
+// Handle messages from parent process
+process.on('message', async (message: DownloadMessage) => {
+  if (!message || message.type !== 'download' || !message.url || !message.executablePath) {
+    process.send?.({ type: 'error', error: 'Invalid request - missing url or executablePath' });
+    return;
+  }
+
+  try {
+    // Launch browser if not already launched
+    if (!browser) {
+      browser = await puppeteer.launch({
+        headless: true,
+        executablePath: message.executablePath,
+        args: [
+          '--no-sandbox',
+          '--disable-setuid-sandbox',
+          '--disable-dev-shm-usage',
+          '--disable-gpu',
+          '--disable-software-rasterizer',
+        ],
+      });
+    }
+
+    const page = await browser.newPage();
+
+    try {
+      const {
+        waitForSelector,
+        cookies,
+        headers,
+        gotoOptions,
+        userAgent,
+        viewport,
+      } = message.options;
+
+      if (cookies?.length) {
+        await page.setCookie(...cookies);
+      }
+
+      if (headers && Object.keys(headers).length) {
+        await page.setExtraHTTPHeaders(headers);
+      }
+
+      if (userAgent) {
+        await page.setUserAgent(userAgent);
+      }
+
+      if (viewport) {
+        await page.setViewport(viewport);
+      }
+
+      const response = await page.goto(message.url, {
+        waitUntil: gotoOptions?.waitUntil || 'networkidle0',
+        ...gotoOptions,
+      });
+
+      if (!response) {
+        throw new Error(`Failed to get response from ${message.url}`);
+      }
+
+      if (waitForSelector) {
+        await page.waitForSelector(waitForSelector.selector, {
+          hidden: waitForSelector.hidden,
+          timeout: waitForSelector.timeout,
+          visible: waitForSelector.visible,
+        });
+      }
+
+      const contentType = response.headers()['content-type'];
+      
+      // Get the raw response data
+      const rawResponse = await page.evaluate(async () => {
+        const response = await fetch(window.location.href);
+        const arrayBuffer = await response.arrayBuffer();
+        return Array.from(new Uint8Array(arrayBuffer));
+      });
+
+      const buffer = Buffer.from(rawResponse);
+      const contentLength = buffer.length;
+
+      // Send metadata first
+      process.send?.({
+        type: 'metadata',
+        contentType,
+        contentLength,
+        status: response.status(),
+      });
+
+      // Send the buffer in chunks to avoid memory issues
+      const chunkSize = 1024 * 1024; // 1MB chunks
+      for (let i = 0; i < buffer.length; i += chunkSize) {
+        const chunk = buffer.slice(i, i + chunkSize);
+        process.send?.({
+          type: 'data',
+          data: chunk.toString('base64'),
+          bytesReceived: i + chunk.length,
+          contentLength: buffer.length,
+        });
+      }
+
+      process.send?.({ type: 'end' });
+    } finally {
+      await page.close();
+    }
+  } catch (error) {
+    process.send?.({
+      type: 'error',
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+}); 


### PR DESCRIPTION
this adds multiple options for downloads directly of the binary response in the browser.

i have test examples in postman of:

* html content directly (using all 3 browsers)
* image content directly (using all 3 browsers)
* pdf content not being protected (using all 3 browsers)
* pdf content being protected (using all 3 browsers)

with the correctly crafted request, this also gets round the protection on the initial file that launches this issue.

the endpoint is /site-download - but could be refined to another endpoint if we feel theres a better option.