### PR TITLE
Don't run clean when doing builds

### DIFF
--- a/bin/browserless.js
+++ b/bin/browserless.js
@@ -144,9 +144,6 @@ const clean = async () =>
  * and validation. Doesn't start the HTTP server.
  */
 const build = async () => {
-  log(`Cleaning build directory`);
-  await clean();
-
   log(`Compiling TypeScript`);
   await buildTypeScript(buildDir, projectDir);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.28.0",
       "license": "SSPL",
       "dependencies": {
-        "@typescript-eslint/parser": "^8.31.0",
         "debug": "^4.4.0",
         "del": "^8.0.0",
         "enjoi": "^9.0.1",


### PR DESCRIPTION
Downstream projects often have other assets in `build` that should remain. Only remove these when `clean` is explicitly ran