### PR TITLE
fix: duplicated user-data-dir and unit tests

### DIFF
--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -547,6 +547,12 @@ export class BrowserManager {
         ?.find((arg) => arg.includes('--user-data-dir='))
         ?.split('=')[1] || (launchOptions as CDPLaunchOptions).userDataDir;
 
+    if (manualUserDataDir && launchOptions.args) {
+      launchOptions.args = launchOptions.args.filter(
+        (arg) => !arg.includes('--user-data-dir='),
+      );
+    }
+
     // Always specify a user-data-dir since plugins can "inject" their own
     // unless it's playwright which takes care of its own data-dirs
     const userDataDir =

--- a/src/routes/chromium/tests/websocket.spec.ts
+++ b/src/routes/chromium/tests/websocket.spec.ts
@@ -222,7 +222,7 @@ describe('Chromium WebSocket API', function () {
   });
 
   it('allows specified user-data-dirs', async () => {
-    const dataDir = '/tmp/data-dir';
+    const dataDir = '/tmp/data-dir-1';
     const config = new Config();
     config.setToken('browserless');
     const metrics = new Metrics();


### PR DESCRIPTION
This PR avoids spawning a browser process with more than one `user-data-dir`, which can happen: 
![image](https://github.com/user-attachments/assets/7223e4ab-1096-4cdd-bcd1-969fdd9f5678)

It also fixed the CI pipeline by renaming the `user-data-dir` used in the Chromium websocket unit test