### PR TITLE
Pressure endpoint returns 503 when there is pressure

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -36,6 +36,11 @@ export const errorCodes = {
     description: `An internal error occurred when handling the request.`,
     message: 'HTTP/1.1 500 Internal Server Error',
   },
+  503: {
+    code: 503,
+    description: 'The service is temporarily unavailable.',
+    message: 'HTTP/1.1 503 Service Unavailable',
+  },
 } as const;
 
 export const okCodes = {

--- a/src/routes/management/http/pressure.get.ts
+++ b/src/routes/management/http/pressure.get.ts
@@ -118,6 +118,8 @@ export default class PressureGetRoute extends HTTPRoute {
           ? 'Memory is over the configured maximum for memory percent'
           : '';
 
+    const statusCode = !hasCapacity || cpuOverloaded || memoryOverloaded ? 503 : 200;
+
     const response: ResponseSchema = {
       pressure: {
         cpu,
@@ -134,6 +136,6 @@ export default class PressureGetRoute extends HTTPRoute {
       },
     };
 
-    return jsonResponse(res, 200, response);
+    return jsonResponse(res, statusCode, response);
   }
 }


### PR DESCRIPTION
**Context for this PR:** We're running Browserless in a Kubernetes environment, where we want to configure separate liveness and readiness probes. The liveness probe ensures the pod is still alive, for the readiness endpoint, we want to use `/pressure`, because this endpoint knows when there is no capacity, CPU overload, or memory overload.

However, currently it only returns a `200` status code > making it unsuitable for this purpose.

This change ensures that when there is no capacity, or when there's a CPU overload, or when there's a memory overload, that the pressure endpoints returns a 503 status code.