### PR TITLE
Refactor install-adblock.js for better file management

### DIFF
--- a/scripts/install-adblock.js
+++ b/scripts/install-adblock.js
@@ -6,9 +6,9 @@ import { createWriteStream, existsSync, mkdirSync } from 'fs';
 import path, { join } from 'path';
 import { Readable } from 'stream';
 import { deleteAsync } from 'del';
-import { moveFile } from 'move-file';
 import os from 'os';
 import unzip from 'extract-zip';
+import fsExtra from 'fs-extra';
 
 (async () => {
   const tmpDir = path.join(os.tmpdir(), '_ublite' + Date.now());
@@ -18,35 +18,51 @@ import unzip from 'extract-zip';
     mkdirSync(tmpDir, { recursive: true });
   }
 
-  const zipFile = tmpDir + '/ublock.zip';
-  const tmpUblockLitePath = path.join(tmpDir);
+  const zipFile = join(tmpDir, 'ublock.zip');
   const extensionsDir = join(process.cwd(), 'extensions');
   const uBlockLiteDir = join(extensionsDir, 'ublocklite');
 
-  const downloadUrlToDirectory = (url, dir) =>
+  const downloadUrlToDirectory = (url, filePath) =>
     fetch(url).then(
       (response) =>
         new Promise((resolve, reject) => {
           // @ts-ignore
           Readable.fromWeb(response.body)
-            .pipe(createWriteStream(dir))
+            .pipe(createWriteStream(filePath))
             .on('error', reject)
             .on('finish', resolve);
         }),
     );
 
+  // Delete existing uBlockLite folder if it exists
   if (existsSync(uBlockLiteDir)) {
     await deleteAsync(uBlockLiteDir);
   }
+
+  // Fetch latest release info
   const data = await fetch(
-    'https://api.github.com/repos/uBlockOrigin/uBOL-home/releases/latest',
+    'https://api.github.com/repos/uBlockOrigin/uBOL-home/releases/latest'
   );
   const json = await data.json();
 
+  // Download ZIP
   await downloadUrlToDirectory(json.assets[0].browser_download_url, zipFile);
+
+  // Extract ZIP
   await unzip(zipFile, { dir: tmpDir });
-  await moveFile(join(tmpUblockLitePath), join(extensionsDir, 'ublocklite'));
+
+  // tmpDir is already the extension folder
+  if (!existsSync(join(tmpDir, 'manifest.json'))) {
+    throw new Error('manifest.json not found in extracted folder');
+  }
+
+  // Move folder to extensions directory
+  await fsExtra.move(tmpDir, uBlockLiteDir, { overwrite: true });
+
+  // Clean up ZIP file
   await deleteAsync(zipFile, { force: true }).catch((err) => {
     console.warn('Could not delete temporary download file: ' + err.message);
   });
+
+  console.log('✅ uBlock Lite installed successfully!');
 })();


### PR DESCRIPTION
I always ended up with this error:

```bash
> @browserless.io/browserless@2.34.1 install:adblock
> node scripts/install-adblock.js

node:internal/fs/promises:623
  return await PromisePrototypeThen(
         ^

Error: EISDIR: illegal operation on a directory, copyfile '/tmp/_ublite1757499380011' -> '/opt/browserless/extensions/ublocklite'
    at async Object.copyFile (node:internal/fs/promises:623:10)
    at async _moveFile (file:///opt/browserless/node_modules/move-file/index.js:50:4)
    at async file:///opt/browserless/scripts/install-adblock.js:48:3 {
  errno: -21,
  code: 'EISDIR',
  syscall: 'copyfile',
  path: '/tmp/_ublite1757499380011',
  dest: '/opt/browserless/extensions/ublocklite'
}
```

This pr aims to resolve the issue.

Please review carefully, I'm of no means a js dev.