### PR TITLE
Drop --production=false

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -67,4 +67,4 @@ RUN groupadd -r blessuser && useradd --uid ${BLESS_USER_ID} -r -g blessuser -G a
   mkdir -p /home/blessuser/Downloads && \
   chown -R blessuser:blessuser /home/blessuser
 
-RUN npm clean-install --production=false
+RUN npm clean-install

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Install all dependencies for tests
-npm clean-install --production=false
+npm clean-install
 
 # Setup Env Variables
 export DEBUG=-*


### PR DESCRIPTION
May be needed for CI as we have dependencies required at build time to do TS/tests.