### PR TITLE
fix: use acceptInsecureCerts launch param instead of ignoreHTTPSErrors

### DIFF
--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -567,6 +567,16 @@ export class BrowserManager {
     );
 
     /**
+     * Handle deprecated launch options
+     */
+    if (Object.hasOwn(launchOptions, 'ignoreHTTPSErrors')) {
+      if (!Object.hasOwn(launchOptions, 'acceptInsecureCerts')) {
+        (launchOptions as CDPLaunchOptions).acceptInsecureCerts = (launchOptions as CDPLaunchOptions).ignoreHTTPSErrors;
+      }
+      delete (launchOptions as CDPLaunchOptions).ignoreHTTPSErrors;
+    }
+
+    /**
      * If it is a playwright request
      */
     if (

--- a/src/routes/chrome/tests/content.spec.ts
+++ b/src/routes/chrome/tests/content.spec.ts
@@ -373,4 +373,28 @@ describe('/chrome/content API', function () {
       expect(res.status).to.equal(200);
     });
   });
+
+  it('can accept insecure certs', async () => {
+    const config = new Config();
+    config.setToken('browserless');
+    const metrics = new Metrics();
+    await start({ config, metrics });
+
+    const body = {
+      gotoOptions: {
+        waitUntil: `networkidle2`,
+      },
+      url: 'https://self-signed.badssl.com',
+    };
+
+    await fetch('http://localhost:3000/chrome/content?token=browserless&launch={"acceptInsecureCerts":true}', {
+      body: JSON.stringify(body),
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    }).then(async (res) => {
+      expect(res.status).to.equal(200);
+    });
+  });
 });

--- a/src/routes/chromium/tests/content.spec.ts
+++ b/src/routes/chromium/tests/content.spec.ts
@@ -399,4 +399,28 @@ describe('/chromium/content API', function () {
       expect(res.status).to.equal(200);
     });
   });
+
+  it('can accept insecure certs', async () => {
+    const config = new Config();
+    config.setToken('browserless');
+    const metrics = new Metrics();
+    await start({ config, metrics });
+
+    const body = {
+      gotoOptions: {
+        waitUntil: `networkidle2`,
+      },
+      url: 'https://self-signed.badssl.com',
+    };
+
+    await fetch('http://localhost:3000/chromium/content?token=browserless&launch={"acceptInsecureCerts":true}', {
+      body: JSON.stringify(body),
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    }).then(async (res) => {
+      expect(res.status).to.equal(200);
+    });
+  });
 });

--- a/src/routes/edge/tests/content.spec.ts
+++ b/src/routes/edge/tests/content.spec.ts
@@ -373,4 +373,28 @@ describe('/edge/content API', function () {
       expect(res.status).to.equal(200);
     });
   });
+
+  it('can accept insecure certs', async () => {
+    const config = new Config();
+    config.setToken('browserless');
+    const metrics = new Metrics();
+    await start({ config, metrics });
+
+    const body = {
+      gotoOptions: {
+        waitUntil: `networkidle2`,
+      },
+      url: 'https://self-signed.badssl.com',
+    };
+
+    await fetch('http://localhost:3000/edge/content?token=browserless&launch={"acceptInsecureCerts":true}', {
+      body: JSON.stringify(body),
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    }).then(async (res) => {
+      expect(res.status).to.equal(200);
+    });
+  });
 });

--- a/src/shim.spec.ts
+++ b/src/shim.spec.ts
@@ -174,6 +174,24 @@ describe('Request Shimming', () => {
     });
   });
 
+  describe('insecure certs', () => {
+    it('converts ignoreHTTPSErrors to acceptInsecureCerts', () => {
+      const url = 'wss://localhost?ignoreHTTPSErrors';
+      const final = 'wss://localhost/?launch={"acceptInsecureCerts":true}';
+      const shimmed = shimLegacyRequests(new URL(url));
+
+      expect(decodeURIComponent(shimmed.href)).to.equal(final);
+    });
+
+    it('acceptInsecureCerts takes precedence over ignoreHTTPSErrors', () => {
+      const url = 'wss://localhost?ignoreHTTPSErrors&launch={"acceptInsecureCerts":false}';
+      const final = 'wss://localhost/?launch={"acceptInsecureCerts":false}';
+      const shimmed = shimLegacyRequests(new URL(url));
+
+      expect(decodeURIComponent(shimmed.href)).to.equal(final);
+    });
+  });
+
   describe('token shimming', () => {
     it('converts token query parameters to an authorization header', () => {
       const url = 'wss://localhost?token=12345';

--- a/src/shim.ts
+++ b/src/shim.ts
@@ -5,7 +5,7 @@ import {
   safeParse,
 } from '@browserless.io/browserless';
 
-const shimParam = ['headless', 'stealth', 'ignoreDefaultArgs', 'slowMo'];
+const shimParam = ['headless', 'stealth', 'ignoreDefaultArgs', 'slowMo', 'ignoreHTTPSErrors'];
 
 /**
  * Obfuscates the ?token parameter by shifting it to a header instead of a query-parameter.
@@ -72,6 +72,20 @@ export function shimLegacyRequests(url: URL): URL {
       launchParams.ignoreHTTPSErrors === undefined
     ) {
       launchParams.ignoreHTTPSErrors = ignoreHTTPSErrors !== 'false';
+    }
+
+    // When acceptInsecureCerts is set, ignoreHTTPSErrors is ignored
+    if (launchParams.acceptInsecureCerts !== undefined) {
+      launchParams.ignoreHTTPSErrors = undefined;
+    }
+
+    // When ignoreHTTPSErrors sent, convert it to acceptInsecureCerts
+    if (
+      typeof ignoreHTTPSErrors !== 'undefined' &&
+      launchParams.acceptInsecureCerts === undefined
+    ) {
+      launchParams.acceptInsecureCerts = ignoreHTTPSErrors !== 'false';
+      launchParams.ignoreHTTPSErrors = undefined;
     }
 
     if (

--- a/src/types.ts
+++ b/src/types.ts
@@ -373,7 +373,9 @@ export interface CDPLaunchOptions extends BrowserlessLaunch {
   dumpio?: boolean;
   headless?: boolean | 'shell';
   ignoreDefaultArgs?: boolean | string[];
+  /** @deprecated use acceptInsecureCerts field instead */
   ignoreHTTPSErrors?: boolean;
+  acceptInsecureCerts?: boolean;
   slowMo?: number;
   stealth?: boolean;
   timeout?: number;


### PR DESCRIPTION
Adjusting launch parameters to use new `acceptInsecureCerts` flag, due to https://github.com/puppeteer/puppeteer/pull/12756.
