### PR TITLE
fix(chrome,edge): enforce configured token on page CDP WebSocket route

### DIFF
--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -29,7 +29,9 @@ import {
   exists,
   generateDataDir,
   getFinalPathSegment,
+  makeDevtoolsFrontendURL,
   makeExternalURL,
+  makeExternalWebSocketURL,
   noop,
   parseBooleanParam,
   parseStringParam,
@@ -294,9 +296,11 @@ export class BrowserManager {
    * their respective /json/list contents. URLs are modified so that subsequent
    * calls can be forwarded to the appropriate destination
    */
-  public async getJSONList(): Promise<Array<CDPJSONPayload>> {
+  public async getJSONList(
+    token?: string | null,
+  ): Promise<Array<CDPJSONPayload>> {
     const externalAddress = this.config.getExternalWebSocketAddress();
-    const externalURL = new URL(externalAddress);
+    const externalHTTPAddress = this.config.getExternalAddress();
     const sessions = Array.from(this.browsers);
 
     const cdpResponse = await Promise.all(
@@ -310,33 +314,38 @@ export class BrowserManager {
           );
           if (cdpJSON) {
             return cdpJSON.map((c) => {
-              const webSocketDebuggerURL = new URL(c.webSocketDebuggerUrl);
-              const devtoolsFrontendURL = new URL(
-                c.devtoolsFrontendUrl,
+              const internalWebSocketURL = new URL(c.webSocketDebuggerUrl);
+              const webSocketDebuggerURL = makeExternalWebSocketURL(
                 externalAddress,
+                internalWebSocketURL.pathname,
               );
-              const wsQuery = devtoolsFrontendURL.searchParams.get('ws');
-
-              if (wsQuery) {
-                const paramName = externalURL.protocol.startsWith('wss')
-                  ? 'wss'
-                  : 'ws';
-                devtoolsFrontendURL.searchParams.set(
-                  paramName,
-                  path.join(
-                    webSocketDebuggerURL.host,
-                    webSocketDebuggerURL.pathname,
-                  ),
-                );
-              }
-
-              webSocketDebuggerURL.host = externalURL.host;
-              webSocketDebuggerURL.port = externalURL.port;
-              webSocketDebuggerURL.protocol = externalURL.protocol;
+              const authorizedWebSocketURL = makeExternalWebSocketURL(
+                externalAddress,
+                internalWebSocketURL.pathname,
+                token,
+              );
+              const internalDevtoolsFrontendURL = new URL(
+                c.devtoolsFrontendUrl,
+                externalHTTPAddress,
+              );
+              const devtoolsFrontendURL = new URL(externalHTTPAddress);
+              devtoolsFrontendURL.pathname = path.posix.join(
+                devtoolsFrontendURL.pathname,
+                '/devtools/inspector.html',
+              );
+              const hasWebSocketTarget =
+                internalDevtoolsFrontendURL.searchParams.has('ws') ||
+                internalDevtoolsFrontendURL.searchParams.has('wss');
+              const externalDevtoolsFrontendURL = hasWebSocketTarget
+                ? makeDevtoolsFrontendURL(
+                    devtoolsFrontendURL,
+                    authorizedWebSocketURL,
+                  )
+                : devtoolsFrontendURL;
 
               return {
                 ...c,
-                devtoolsFrontendUrl: devtoolsFrontendURL.href,
+                devtoolsFrontendUrl: externalDevtoolsFrontendURL.href,
                 webSocketDebuggerUrl: webSocketDebuggerURL.href,
               };
             });
@@ -354,6 +363,7 @@ export class BrowserManager {
   protected async generateSessionJson(
     browser: BrowserInstance,
     session: BrowserlessSession,
+    token?: string | null,
   ) {
     const serverHTTPAddress = this.config.getExternalAddress();
     const serverWSAddress = this.config.getExternalWebSocketAddress();
@@ -375,8 +385,6 @@ export class BrowserManager {
     ];
 
     const internalWSEndpoint = browser.wsEndpoint();
-    const externalURI = new URL(serverHTTPAddress);
-    const externalProtocol = externalURI.protocol === 'https:' ? 'wss' : 'ws';
 
     if (this.browserIsChrome(browser) && internalWSEndpoint) {
       const browserURI = new URL(internalWSEndpoint);
@@ -386,23 +394,36 @@ export class BrowserManager {
       if (body) {
         for (const page of body) {
           const pageURI = new URL(page.webSocketDebuggerUrl);
+          const webSocketURL = makeExternalWebSocketURL(
+            serverWSAddress,
+            pageURI.pathname,
+          );
+          const authorizedWebSocketURL = makeExternalWebSocketURL(
+            serverWSAddress,
+            pageURI.pathname,
+            token,
+          );
+          const frontendURL = new URL(serverHTTPAddress);
+          frontendURL.pathname = path.posix.join(
+            frontendURL.pathname,
+            '/devtools/inspector.html',
+          );
+          const externalDevtoolsFrontendURL = makeDevtoolsFrontendURL(
+            frontendURL,
+            authorizedWebSocketURL,
+          );
           const devtoolsFrontendUrl =
-            `/devtools/inspector.html?${externalProtocol}=${externalURI.host}${externalURI.pathname}${pageURI.pathname}`.replace(
-              /\/\//gi,
-              '/',
-            );
+            externalDevtoolsFrontendURL.pathname +
+            externalDevtoolsFrontendURL.search;
 
           // /devtools/browser/b733c56b-8543-489c-b27b-28e12d966c01
-          const browserWSEndpoint = new URL(
-            browserURI.pathname,
+          const browserWSEndpoint = makeExternalWebSocketURL(
             serverWSAddress,
+            browserURI.pathname,
           ).href;
 
           // /devtools/page/802B1FDAD5F75E9BCE92D066DFF13253
-          const webSocketDebuggerUrl = new URL(
-            pageURI.pathname,
-            serverWSAddress,
-          ).href;
+          const webSocketDebuggerUrl = webSocketURL.href;
 
           sessions.push({
             ...sessions[0],
@@ -516,6 +537,7 @@ export class BrowserManager {
 
   public async getAllSessions(
     trackingId?: string,
+    token?: string | null,
   ): Promise<BrowserlessSessionJSON[]> {
     const sessions = Array.from(this.browsers);
 
@@ -524,7 +546,7 @@ export class BrowserManager {
     let formattedSessions: BrowserlessSessionJSON[] = (
       await Promise.all(
         sessions.map(([browser, session]) =>
-          this.generateSessionJson(browser, session).catch((err) => {
+          this.generateSessionJson(browser, session, token).catch((err) => {
             this.log.warn(
               `Error generating session JSON for "${session.id}": ${err}`,
             );

--- a/src/routes/chrome/tests/page-websocket.spec.ts
+++ b/src/routes/chrome/tests/page-websocket.spec.ts
@@ -81,20 +81,35 @@ describe('WebSocket Page API', function () {
     await page.goto('https://one.one.one.one/');
     // @ts-ignore
     const pageId = page.target()._targetId;
-    const webSocketDebuggerUrl = `ws://localhost:3000/devtools/page/${pageId}`;
+    const pageURL = `ws://localhost:3000/devtools/page/${pageId}`;
 
-    // Connect to raw page target without authorization
+    // A token-less connection to the raw page target must be refused when a
+    // TOKEN is configured. The prior assertion lived only inside `catch`, so
+    // it passed vacuously whenever the connection was (wrongly) accepted.
+    let acceptedWithoutToken = false;
     try {
-      new Connection(
-        webSocketDebuggerUrl,
-        await NodeWebSocketTransport.create(webSocketDebuggerUrl),
-      );
+      const transport = await NodeWebSocketTransport.create(pageURL);
+      acceptedWithoutToken = true;
+      transport.close();
     } catch (err: unknown) {
-      //@ts-ignore
+      // @ts-ignore
       expect(err.message).to.include('401');
-    } finally {
-      browser.close();
     }
+    expect(
+      acceptedWithoutToken,
+      'token-less page WebSocket connection must be rejected when TOKEN is set',
+    ).to.be.false;
+
+    // The same target still connects and accepts CDP commands WITH the token.
+    const authedURL = `${pageURL}?token=browserless`;
+    const cdp = new Connection(
+      authedURL,
+      await NodeWebSocketTransport.create(authedURL),
+    );
+    const result = await cdp.send('Page.enable');
+    cdp.dispose();
+    await browser.close();
+    expect(result);
   });
 
   it('404s pages not found', async () => {

--- a/src/routes/chrome/ws/page.ts
+++ b/src/routes/chrome/ws/page.ts
@@ -4,7 +4,6 @@ import { default as Page, QuerySchema } from '../../../shared/page.ws.js';
 export default class ChromePageWebSocketRoute extends Page {
   name = BrowserlessRoutes.ChromePageWebSocketRoute;
   browser = ChromeCDP;
-  auth = false;
 }
 
 export { QuerySchema };

--- a/src/routes/chromium/tests/json.spec.ts
+++ b/src/routes/chromium/tests/json.spec.ts
@@ -120,6 +120,35 @@ describe('/json/ API', function () {
     expect(resJSON.description).to.equal('');
   });
 
+  it('encodes the token in the /json/new DevTools URL', async () => {
+    const token = 'token&with#a+percent%';
+    const config = new Config();
+    config.setToken(token);
+    config.setExternalAddress('https://browserless.example.com/prefix/');
+    const metrics = new Metrics();
+    await start({ config, metrics });
+
+    const res = await fetch(
+      `http://localhost:3000/json/new?token=${encodeURIComponent(token)}`,
+      { method: 'PUT' },
+    );
+    expect(res.status).to.equal(200);
+    const resJSON = await res.json();
+    const frontendURL = new URL(
+      resJSON.devtoolsFrontendUrl,
+      config.getExternalAddress(),
+    );
+    const nestedURL = new URL(`wss://${frontendURL.searchParams.get('wss')}`);
+
+    expect(frontendURL.pathname).to.equal('/prefix/devtools/inspector.html');
+    expect(frontendURL.searchParams.has('ws')).to.be.false;
+    expect(nestedURL.host).to.equal('browserless.example.com');
+    expect(nestedURL.pathname).to.equal('/prefix/devtools/page/' + resJSON.id);
+    expect(nestedURL.searchParams.get('token')).to.equal(token);
+    expect(new URL(resJSON.webSocketDebuggerUrl).searchParams.has('token')).to
+      .be.false;
+  });
+
   it('rejects unauthorized requests to PUT /json/new', async () => {
     const config = new Config();
     config.setToken('browserless');

--- a/src/routes/chromium/tests/websocket.spec.ts
+++ b/src/routes/chromium/tests/websocket.spec.ts
@@ -1,8 +1,10 @@
 import {
   Browserless,
   BrowserlessSessionJSON,
+  CDPJSONPayload,
   Config,
   Hooks,
+  Logger,
   Metrics,
   exists,
   fetchJson,
@@ -13,6 +15,19 @@ import { deleteAsync } from 'del';
 import { expect } from 'chai';
 import fs from 'fs/promises';
 import puppeteer from 'puppeteer-core';
+import WebSocket from 'ws';
+
+class CapturingLogger extends Logger {
+  static messages: string[] = [];
+
+  public trace(...messages: unknown[]) {
+    CapturingLogger.messages.push(messages.join(' '));
+  }
+
+  public warn(...messages: unknown[]) {
+    CapturingLogger.messages.push(messages.join(' '));
+  }
+}
 
 describe('Chromium WebSocket API', function () {
   let browserless: Browserless;
@@ -57,6 +72,143 @@ describe('Chromium WebSocket API', function () {
     });
 
     await browser.close();
+  });
+
+  it('returns externally routable DevTools URLs from /json/list', async () => {
+    const token = 'token&with#a+percent%';
+    const config = new Config();
+    config.setToken(token);
+    config.setExternalAddress('https://browserless.example.com/prefix/');
+    const metrics = new Metrics();
+    await start({ config, metrics });
+
+    const browser = await puppeteer.connect({
+      browserWSEndpoint: `ws://localhost:3000/chromium?token=${encodeURIComponent(token)}`,
+    });
+    const page = await browser.newPage();
+    // @ts-ignore
+    const pageId = page.target()._targetId;
+    const pages = (await fetchJson(
+      `http://localhost:3000/json/list?token=${encodeURIComponent(token)}`,
+    )) as CDPJSONPayload[];
+    const result = pages.find(({ id }) => id === pageId)!;
+    const webSocketURL = new URL(result.webSocketDebuggerUrl);
+    const frontendURL = new URL(result.devtoolsFrontendUrl);
+    const nestedURL = new URL(`wss://${frontendURL.searchParams.get('wss')}`);
+
+    expect(webSocketURL.host).to.equal('browserless.example.com');
+    expect(webSocketURL.pathname).to.equal(`/prefix/devtools/page/${pageId}`);
+    expect(webSocketURL.searchParams.has('token')).to.be.false;
+    expect(frontendURL.origin).to.equal('https://browserless.example.com');
+    expect(frontendURL.pathname).to.equal('/prefix/devtools/inspector.html');
+    expect(frontendURL.searchParams.has('ws')).to.be.false;
+    expect(nestedURL.host).to.equal('browserless.example.com');
+    expect(nestedURL.pathname).to.equal(`/prefix/devtools/page/${pageId}`);
+    expect(nestedURL.searchParams.get('token')).to.equal(token);
+
+    await browser.close();
+  });
+
+  it('returns externally routable DevTools URLs from /sessions', async () => {
+    const token = 'token&with#a+percent%';
+    const config = new Config();
+    config.setToken(token);
+    config.setExternalAddress('https://browserless.example.com/prefix/');
+    const metrics = new Metrics();
+    await start({ config, metrics });
+
+    const browser = await puppeteer.connect({
+      browserWSEndpoint: `ws://localhost:3000/chromium?token=${encodeURIComponent(token)}`,
+    });
+    const page = await browser.newPage();
+    // @ts-ignore
+    const pageId = page.target()._targetId;
+    const sessions = (await fetchJson(
+      `http://localhost:3000/sessions?token=${encodeURIComponent(token)}`,
+    )) as Array<BrowserlessSessionJSON & Partial<CDPJSONPayload>>;
+    const result = sessions.find(({ id }) => id === pageId)!;
+    const webSocketURL = new URL(result.webSocketDebuggerUrl!);
+    const frontendURL = new URL(
+      result.devtoolsFrontendUrl!,
+      config.getExternalAddress(),
+    );
+    const nestedURL = new URL(`wss://${frontendURL.searchParams.get('wss')}`);
+
+    expect(webSocketURL.host).to.equal('browserless.example.com');
+    expect(webSocketURL.pathname).to.equal(`/prefix/devtools/page/${pageId}`);
+    expect(webSocketURL.searchParams.has('token')).to.be.false;
+    expect(frontendURL.pathname).to.equal('/prefix/devtools/inspector.html');
+    expect(frontendURL.searchParams.has('ws')).to.be.false;
+    expect(nestedURL.host).to.equal('browserless.example.com');
+    expect(nestedURL.pathname).to.equal(`/prefix/devtools/page/${pageId}`);
+    expect(nestedURL.searchParams.get('token')).to.equal(token);
+
+    await browser.close();
+  });
+
+  it('redacts nested tokens from all server request URL logs', async () => {
+    const authToken = 'browserless';
+    const nestedToken = 'nested-log-secret';
+    const config = new Config();
+    config.setToken(authToken);
+    const metrics = new Metrics();
+    CapturingLogger.messages = [];
+    browserless = new Browserless({
+      Logger: CapturingLogger,
+      config,
+      metrics,
+    });
+    await browserless.start();
+    (
+      browserless.server as unknown as {
+        logger: Logger;
+      }
+    ).logger = new CapturingLogger('server');
+
+    const nestedURL = new URL(
+      'wss://browserless.example.com/devtools/page/page-id',
+    );
+    nestedURL.searchParams.set('token', nestedToken);
+    const nestedTarget = encodeURIComponent(
+      `${nestedURL.host}${nestedURL.pathname}${nestedURL.search}`,
+    );
+
+    await fetch(
+      `http://localhost:3000/json/list?token=${authToken}&wss=${nestedTarget}`,
+    );
+    await fetch(`http://localhost:3000/missing?wss=${nestedTarget}`);
+
+    const requestWebSocket = (path: string) =>
+      new Promise<void>((resolve, reject) => {
+        const socket = new WebSocket(`ws://localhost:3000${path}`);
+        const timeout = setTimeout(
+          () => reject(new Error(`WebSocket request timed out for ${path}`)),
+          5000,
+        );
+        const done = () => {
+          clearTimeout(timeout);
+          socket.close();
+          resolve();
+        };
+        socket.once('open', done);
+        socket.once('unexpected-response', (_request, response) => {
+          response.resume();
+          done();
+        });
+        socket.once('error', reject);
+      });
+
+    await requestWebSocket(
+      `/devtools/page/BLESSTEST?token=${authToken}&wss=${nestedTarget}`,
+    );
+    await requestWebSocket(`/missing?wss=${nestedTarget}`);
+
+    const requestURLLogs = CapturingLogger.messages.filter((message) =>
+      /request to|request on|route handler for/i.test(message),
+    );
+    expect(requestURLLogs).not.to.be.empty;
+    expect(requestURLLogs.join('\n')).not.to.include(nestedToken);
+    expect(requestURLLogs.join('\n')).to.include('redacted');
   });
 
   it('runs chromium Playwright-CDP requests', async () => {

--- a/src/routes/edge/tests/page-websocket.spec.ts
+++ b/src/routes/edge/tests/page-websocket.spec.ts
@@ -81,20 +81,35 @@ describe('WebSocket Page API', function () {
     await page.goto('https://one.one.one.one/');
     // @ts-ignore
     const pageId = page.target()._targetId;
-    const webSocketDebuggerUrl = `ws://localhost:3000/devtools/page/${pageId}`;
+    const pageURL = `ws://localhost:3000/devtools/page/${pageId}`;
 
-    // Connect to raw page target without authorization
+    // A token-less connection to the raw page target must be refused when a
+    // TOKEN is configured. The prior assertion lived only inside `catch`, so
+    // it passed vacuously whenever the connection was (wrongly) accepted.
+    let acceptedWithoutToken = false;
     try {
-      new Connection(
-        webSocketDebuggerUrl,
-        await NodeWebSocketTransport.create(webSocketDebuggerUrl),
-      );
+      const transport = await NodeWebSocketTransport.create(pageURL);
+      acceptedWithoutToken = true;
+      transport.close();
     } catch (err: unknown) {
-      //@ts-ignore
+      // @ts-ignore
       expect(err.message).to.include('401');
-    } finally {
-      browser.close();
     }
+    expect(
+      acceptedWithoutToken,
+      'token-less page WebSocket connection must be rejected when TOKEN is set',
+    ).to.be.false;
+
+    // The same target still connects and accepts CDP commands WITH the token.
+    const authedURL = `${pageURL}?token=browserless`;
+    const cdp = new Connection(
+      authedURL,
+      await NodeWebSocketTransport.create(authedURL),
+    );
+    const result = await cdp.send('Page.enable');
+    cdp.dispose();
+    await browser.close();
+    expect(result);
   });
 
   it('404s pages not found', async () => {

--- a/src/routes/edge/ws/page.ts
+++ b/src/routes/edge/ws/page.ts
@@ -4,7 +4,6 @@ import { default as Page, QuerySchema } from '../../../shared/page.ws.js';
 export default class EdgePageWebSocketRoute extends Page {
   name = BrowserlessRoutes.EdgePageWebSocketRoute;
   browser = EdgeCDP;
-  auth = false;
 }
 
 export { QuerySchema };

--- a/src/routes/management/http/sessions.get.ts
+++ b/src/routes/management/http/sessions.get.ts
@@ -8,6 +8,7 @@ import {
   Request,
   SystemQueryParameters,
   contentTypes,
+  getTokenFromRequest,
   jsonResponse,
 } from '@browserless.io/browserless';
 import { ServerResponse } from 'http';
@@ -26,15 +27,17 @@ export default class SessionsGetRoute extends HTTPRoute {
   browser = null;
   concurrency = false;
   contentTypes = [contentTypes.json];
-  description = `Lists all currently running sessions and relevant meta-data excluding potentially open pages.`;
+  description = `Lists all currently running sessions and relevant meta-data. Page entries can include a directly usable "devtoolsFrontendUrl" containing the API token inside its nested WebSocket URL; treat this field as credential-bearing and redact query strings from proxy and access logs.`;
   method = Methods.get;
   path = HTTPManagementRoutes.sessions;
   tags = [APITags.management];
   async handler(req: Request, res: ServerResponse): Promise<void> {
     const trackingId = (req.queryParams.trackingId as string) || undefined;
     const browserManager = this.browserManager();
-    const response: ResponseSchema =
-      await browserManager.getAllSessions(trackingId);
+    const response: ResponseSchema = await browserManager.getAllSessions(
+      trackingId,
+      getTokenFromRequest(req),
+    );
 
     return jsonResponse(res, 200, response);
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,7 @@ import {
   WebSocketRoute,
   contentTypes,
   convertPathToURL,
+  formatRequestURLForLog,
   isMatch,
   moveTokenToHeader,
   queryParamsToObject,
@@ -193,7 +194,7 @@ export class HTTPServer extends EventEmitter {
     const request = req as http.IncomingMessage;
     request.url = moveTokenToHeader(request);
     this.logger.trace(
-      `Handling inbound HTTP request on "${request.method}: ${request.url || ''}"`,
+      `Handling inbound HTTP request on "${request.method}: ${formatRequestURLForLog(request.url || '')}"`,
     );
 
     const proceed = await this.hooks.before({ req, res });
@@ -245,7 +246,7 @@ export class HTTPServer extends EventEmitter {
 
     if (!route) {
       this.logger.warn(
-        `No matching HTTP route handler for "${req.method}: ${req.parsed.href}"`,
+        `No matching HTTP route handler for "${req.method}: ${formatRequestURLForLog(req.parsed.href)}"`,
       );
       writeResponse(
         res,
@@ -262,7 +263,9 @@ export class HTTPServer extends EventEmitter {
     }
 
     if (route?.auth) {
-      this.logger.trace(`Authorizing HTTP request to "${request.url || ''}"`);
+      this.logger.trace(
+        `Authorizing HTTP request to "${formatRequestURLForLog(request.url || '')}"`,
+      );
       const isPermitted = await this.token.isAuthorized(req, route);
 
       if (!isPermitted) {
@@ -421,7 +424,7 @@ export class HTTPServer extends EventEmitter {
     request.url = moveTokenToHeader(request);
 
     this.logger.trace(
-      `Handling inbound WebSocket request on "${request.url || ''}"`,
+      `Handling inbound WebSocket request on "${formatRequestURLForLog(request.url || '')}"`,
     );
     const proceed = await this.hooks.before({ head, req, socket });
     req.parsed = convertPathToURL(request.url || '', this.config);
@@ -444,7 +447,7 @@ export class HTTPServer extends EventEmitter {
 
       if (route?.auth) {
         this.logger.trace(
-          `Authorizing WebSocket request to "${req.parsed.href}"`,
+          `Authorizing WebSocket request to "${formatRequestURLForLog(req.parsed.href)}"`,
         );
         const isPermitted = await this.token.isAuthorized(req, route);
 
@@ -506,7 +509,7 @@ export class HTTPServer extends EventEmitter {
     }
 
     this.logger.warn(
-      `No matching WebSocket route handler for "${req.parsed.href}"`,
+      `No matching WebSocket route handler for "${formatRequestURLForLog(req.parsed.href)}"`,
     );
     return writeResponse(socket, 404, 'Not Found');
   }

--- a/src/shared/json-list.http.ts
+++ b/src/shared/json-list.http.ts
@@ -9,6 +9,7 @@ import {
   Response,
   contentTypes,
   dedent,
+  getTokenFromRequest,
   jsonResponse,
 } from '@browserless.io/browserless';
 
@@ -25,13 +26,19 @@ export default class ChromiumJSONListGetRoute extends HTTPRoute {
     Returns a JSON payload that acts as a pass-through to the DevTools /json/list HTTP API in Chromium and Chrome.
     Browserless crafts this payload so that remote clients can connect to the underlying "webSocketDebuggerUrl"
     properly, excluding any API tokens in that URL. If under authentication be sure to include your authorization.
+    The "devtoolsFrontendUrl" remains directly usable and can contain the API token inside its nested WebSocket URL;
+    treat this field as credential-bearing and redact query strings from proxy and access logs.
   `);
   method = Methods.get;
   path = HTTPRoutes.jsonList;
   tags = [APITags.browserAPI];
 
-  async handler(_req: Request, res: Response): Promise<void> {
+  async handler(req: Request, res: Response): Promise<void> {
     const browserManage = this.browserManager();
-    return jsonResponse(res, 200, await browserManage.getJSONList());
+    return jsonResponse(
+      res,
+      200,
+      await browserManage.getJSONList(getTokenFromRequest(req)),
+    );
   }
 }

--- a/src/shared/json-new.http.ts
+++ b/src/shared/json-new.http.ts
@@ -9,7 +9,10 @@ import {
   Response,
   contentTypes,
   dedent,
+  getTokenFromRequest,
   jsonResponse,
+  makeDevtoolsFrontendURL,
+  makeExternalWebSocketURL,
   pageID,
 } from '@browserless.io/browserless';
 import path from 'path';
@@ -38,31 +41,46 @@ export default class ChromiumJSONNewPutRoute extends HTTPRoute {
   description = dedent(`
     Returns a JSON payload that acts as a pass-through to the DevTools /json/new HTTP API in Chromium.
     Browserless mocks this payload so that remote clients can connect to the underlying "webSocketDebuggerUrl"
-    which will cause Browserless to start the browser and proxy that request into a blank page.
+    which will cause Browserless to start the browser and proxy that request into a blank page. The
+    "webSocketDebuggerUrl" excludes API tokens, so authenticated clients must add their authorization when connecting.
+    The "devtoolsFrontendUrl" remains directly usable and can contain the API token inside its nested WebSocket URL;
+    treat this field as credential-bearing and redact query strings from proxy and access logs.
   `);
   method = Methods.put;
   path = HTTPRoutes.jsonNew;
   tags = [APITags.browserAPI];
 
-  async handler(_req: Request, res: Response): Promise<void> {
+  async handler(req: Request, res: Response): Promise<void> {
     const config = this.config();
     const externalAddress = config.getExternalWebSocketAddress();
     const id = pageID();
-    const { protocol, host, pathname, href } = new URL(
-      `/devtools/page/${id}`,
+    const pagePath = `/devtools/page/${id}`;
+    const webSocketURL = makeExternalWebSocketURL(externalAddress, pagePath);
+    const token = getTokenFromRequest(req);
+    const authorizedWebSocketURL = makeExternalWebSocketURL(
       externalAddress,
+      pagePath,
+      token,
     );
-    const param = protocol.includes('wss') ? 'wss' : 'ws';
-    const value = path.join(host, pathname);
+    const frontendURL = new URL(config.getExternalAddress());
+    frontendURL.pathname = path.posix.join(
+      frontendURL.pathname,
+      '/devtools/inspector.html',
+    );
+    const devtoolsFrontendURL = makeDevtoolsFrontendURL(
+      frontendURL,
+      authorizedWebSocketURL,
+    );
 
     return jsonResponse(res, 200, {
       description: '',
-      devtoolsFrontendUrl: `/devtools/inspector.html?${param}=${value}`,
+      devtoolsFrontendUrl:
+        devtoolsFrontendURL.pathname + devtoolsFrontendURL.search,
       id,
       title: 'New Tab',
       type: 'page',
       url: 'about:blank',
-      webSocketDebuggerUrl: href,
+      webSocketDebuggerUrl: webSocketURL.href,
     });
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -669,7 +669,10 @@ export interface CDPJSONPayload {
   description: string;
 
   /**
-   * The fully-qualified URL of the Devtools inspector app.
+   * The fully-qualified URL of the DevTools inspector app. When
+   * authentication is configured, this URL can contain the API token inside
+   * its nested `ws` or `wss` parameter. Treat the entire URL as
+   * credential-bearing and redact query strings from access logs.
    */
   devtoolsFrontendUrl: string;
 

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,10 +1,13 @@
 import { expect } from 'chai';
-import { ServerResponse } from 'http';
+import { IncomingMessage, ServerResponse } from 'http';
 import { Socket } from 'net';
 import {
   contentTypes,
+  formatRequestURLForLog,
   getFinalPathSegment,
   getPageContent,
+  makeDevtoolsFrontendURL,
+  makeExternalWebSocketURL,
   toSetContentOptions,
   writeResponse,
 } from '@browserless.io/browserless';
@@ -66,6 +69,128 @@ describe('Utils', () => {
           'wss://www.browserless.io/some/random/path/segment/&bad=query',
         ),
       ).to.equal('segment');
+    });
+  });
+
+  describe('#makeExternalWebSocketURL', () => {
+    it('preserves the external path prefix without exposing a token', () => {
+      const url = makeExternalWebSocketURL(
+        'wss://browserless.example.com/prefix/',
+        '/devtools/page/page-id',
+      );
+
+      expect(url.href).to.equal(
+        'wss://browserless.example.com/prefix/devtools/page/page-id',
+      );
+      expect(url.searchParams.has('token')).to.be.false;
+    });
+
+    it('encodes tokens containing URL delimiters', () => {
+      const token = 'token&with#a+percent%';
+      const url = makeExternalWebSocketURL(
+        'wss://browserless.example.com/prefix/',
+        '/devtools/page/page-id',
+        token,
+      );
+
+      expect(url.searchParams.get('token')).to.equal(token);
+    });
+  });
+
+  describe('#makeDevtoolsFrontendURL', () => {
+    it('uses the external WebSocket URL and encodes its nested token', () => {
+      const token = 'token&with#a+percent%';
+      const webSocketURL = makeExternalWebSocketURL(
+        'wss://browserless.example.com/prefix/',
+        '/devtools/page/page-id',
+        token,
+      );
+      const frontendURL = makeDevtoolsFrontendURL(
+        new URL(
+          'https://browserless.example.com/prefix/devtools/inspector.html?ws=127.0.0.1:9222/devtools/page/page-id',
+        ),
+        webSocketURL,
+      );
+
+      expect(frontendURL.searchParams.has('ws')).to.be.false;
+      const nestedURL = new URL(`wss://${frontendURL.searchParams.get('wss')}`);
+      expect(nestedURL.host).to.equal('browserless.example.com');
+      expect(nestedURL.pathname).to.equal('/prefix/devtools/page/page-id');
+      expect(nestedURL.searchParams.get('token')).to.equal(token);
+    });
+  });
+
+  describe('#formatRequestURLForLog', () => {
+    for (const protocol of ['ws', 'wss']) {
+      it(`redacts a token nested in ${protocol} without mutating the request`, () => {
+        const nestedURL = new URL(
+          `${protocol}://browserless.example.com/prefix/devtools/page/page-id`,
+        );
+        nestedURL.searchParams.set('token', 'super-secret');
+        nestedURL.searchParams.set('keep', 'visible');
+        const originalURL =
+          `/devtools/inspector.html?trackingId=track-1&${protocol}=` +
+          encodeURIComponent(
+            `${nestedURL.host}${nestedURL.pathname}${nestedURL.search}`,
+          );
+        const request = {
+          headers: { authorization: 'Bearer auth-token' },
+          url: originalURL,
+        } as unknown as IncomingMessage;
+
+        const formatted = formatRequestURLForLog(request.url!);
+        const parsed = new URL(formatted, 'http://localhost');
+        const nested = new URL(
+          `${protocol}://${parsed.searchParams.get(protocol)}`,
+        );
+
+        expect(formatted).not.to.include('super-secret');
+        expect(parsed.pathname).to.equal('/devtools/inspector.html');
+        expect(parsed.searchParams.get('trackingId')).to.equal('track-1');
+        expect(nested.host).to.equal('browserless.example.com');
+        expect(nested.pathname).to.equal('/prefix/devtools/page/page-id');
+        expect(nested.searchParams.get('token')).to.equal('[redacted]');
+        expect(nested.searchParams.get('keep')).to.equal('visible');
+        expect(request.url).to.equal(originalURL);
+        expect(request.headers.authorization).to.equal('Bearer auth-token');
+      });
+    }
+
+    it('redacts a top-level token without mutating the input', () => {
+      const originalURL = '/json/list?token=super-secret&trackingId=track-1';
+      const formatted = formatRequestURLForLog(originalURL);
+      const parsed = new URL(formatted, 'http://localhost');
+
+      expect(formatted).not.to.include('super-secret');
+      expect(parsed.searchParams.get('token')).to.equal('[redacted]');
+      expect(parsed.searchParams.get('trackingId')).to.equal('track-1');
+      expect(originalURL).to.equal(
+        '/json/list?token=super-secret&trackingId=track-1',
+      );
+    });
+
+    it('preserves an absolute URL while redacting its token', () => {
+      const originalURL =
+        'http://localhost:3000/json/list?token=super-secret&trackingId=track-1';
+      const formatted = formatRequestURLForLog(originalURL);
+
+      expect(formatted).to.equal(
+        'http://localhost:3000/json/list?token=%5Bredacted%5D&trackingId=track-1',
+      );
+    });
+
+    it('redacts nested tokens from malformed WebSocket targets', () => {
+      const originalURL =
+        '/devtools/inspector.html?ws=' +
+        encodeURIComponent('%%%?token=super-secret&keep=visible');
+      const formatted = formatRequestURLForLog(originalURL);
+      const parsed = new URL(formatted, 'http://localhost');
+      const nested = parsed.searchParams.get('ws')!;
+
+      expect(formatted).not.to.include('super-secret');
+      expect(nested).to.include('token=%5Bredacted%5D');
+      expect(nested).to.include('keep=visible');
+      expect(originalURL).to.include('super-secret');
     });
   });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -310,6 +310,59 @@ export const safeParse = (maybeJson: string): unknown | null => {
   }
 };
 
+const redactNestedToken = (protocol: string, value: string): string => {
+  try {
+    const nested = new URL(`${protocol}://${value}`);
+    if (!nested.searchParams.has('token')) {
+      return value;
+    }
+
+    nested.searchParams.set('token', '[redacted]');
+    return `${nested.host}${nested.pathname}${nested.search}`;
+  } catch {
+    const queryIndex = value.indexOf('?');
+    if (queryIndex === -1) {
+      return value;
+    }
+
+    const searchParams = new URLSearchParams(value.slice(queryIndex + 1));
+    if (!searchParams.has('token')) {
+      return value;
+    }
+
+    searchParams.set('token', '[redacted]');
+    return `${value.slice(0, queryIndex)}?${searchParams}`;
+  }
+};
+
+/**
+ * Returns a request URL safe for logging without mutating the request used for
+ * authentication and routing. Tokens nested in DevTools `ws` and `wss`
+ * parameters are redacted as well as top-level token parameters.
+ */
+export function formatRequestURLForLog(url: string): string {
+  const isAbsoluteURL = URL.canParse(url);
+  const parsed = new URL(url, 'http://localhost');
+
+  if (parsed.searchParams.has('token')) {
+    parsed.searchParams.set('token', '[redacted]');
+  }
+
+  for (const protocol of ['ws', 'wss']) {
+    const values = parsed.searchParams.getAll(protocol);
+    if (!values.length) {
+      continue;
+    }
+
+    parsed.searchParams.delete(protocol);
+    for (const value of values) {
+      parsed.searchParams.append(protocol, redactNestedToken(protocol, value));
+    }
+  }
+
+  return isAbsoluteURL ? parsed.href : parsed.pathname + parsed.search;
+}
+
 const sensitiveBodyFields = [
   'authenticate',
   'authorization',
@@ -721,6 +774,35 @@ export const makeExternalURL = (
 
   return new URL(path.join(externalURL.pathname, ...parts), externalAddress)
     .href;
+};
+
+export const makeExternalWebSocketURL = (
+  externalAddress: string,
+  pathname: string,
+  token?: string | null,
+): URL => {
+  const externalURL = new URL(makeExternalURL(externalAddress, pathname));
+
+  if (token) {
+    externalURL.searchParams.set('token', token);
+  }
+
+  return externalURL;
+};
+
+export const makeDevtoolsFrontendURL = (
+  frontendURL: URL,
+  webSocketURL: URL,
+): URL => {
+  const externalFrontendURL = new URL(frontendURL.href);
+  const param = webSocketURL.protocol === 'wss:' ? 'wss' : 'ws';
+  const value = `${webSocketURL.host}${webSocketURL.pathname}${webSocketURL.search}`;
+
+  externalFrontendURL.searchParams.delete('ws');
+  externalFrontendURL.searchParams.delete('wss');
+  externalFrontendURL.searchParams.set(param, value);
+
+  return externalFrontendURL;
 };
 
 export class BadRequest extends Error {


### PR DESCRIPTION
## Problem

When the service is started with a `TOKEN`, the **chrome** and **edge** page CDP WebSocket routes did not enforce it. Both routes overrode the base route with `auth = false`, so the server's token check was skipped for `/devtools/page/*` upgrades.

Effect on a token-protected instance:

- A client with **no token** could open a page target and run arbitrary CDP commands (e.g. `Runtime.evaluate`, `Page.navigate`).
- `chromium` and the base route were unaffected — they returned `401` for the same request.

The `auth = false` override was originally added so the token-less `devtoolsFrontendUrl` inspector link kept working; the fix preserves that link while restoring auth.

## Changes

- **Remove the `auth = false` overrides** on the chrome and edge page WebSocket routes so both inherit the base route's `auth = true`. Page CDP auth is now consistent across chrome, edge, chromium, and multi.
- **Keep DevTools links usable under auth**: thread the requesting token into the generated `devtoolsFrontendUrl` for `/json/list`, `/json/new`, and `/sessions`, via new `makeExternalWebSocketURL` / `makeDevtoolsFrontendURL` helpers. `webSocketDebuggerUrl` continues to exclude the token by design (clients add their own authorization when connecting).
  - This also fixes a pre-existing issue where `/json/list` built its inspector link from Chrome's own (Google-hosted) frontend with the nested WebSocket pointing at the internal browser port — not reachable by an external client. It is now self-hosted and externally routable, with sub-path prefixes preserved.
- **Redact tokens from request-URL logs** (top-level `token`, and tokens nested in DevTools `ws`/`wss` params) without mutating the request used for auth/routing. Document `devtoolsFrontendUrl` as credential-bearing.
- **Non-vacuous regression tests** for chrome and edge: the previous "rejects unauthorized" tests asserted only inside a `catch` block, so they passed without executing whenever the connection was wrongly accepted. New tests fail if a token-less page connection is accepted while a token is configured, and confirm the authorized connection still runs CDP. Added coverage for the token-carrying DevTools URLs (`/json/list`, `/json/new`, `/sessions`) and the URL helpers.

## Verification

Built and run locally in Docker (chromium; chrome and edge validated on `linux/amd64`):

- Token-less page WebSocket connection → `401` on chrome, edge, and chromium (previously accepted on chrome/edge).
- Authorized page WebSocket connection → connects and executes CDP.
- `devtoolsFrontendUrl` from `/json/new` and `/json/list` loads the inspector asset and connects with the embedded token; the same target with the token stripped is refused.
- With no `TOKEN` configured, behavior is unchanged (page connections and `/json/list` work without a token).

## Behavior change (worth a release note)

On token-protected `chrome`/`edge`/`multi`, a client that connects to a raw page target (`/devtools/page/*`) **without** a token now receives `401`. This matches `chromium`'s existing behavior. `webSocketDebuggerUrl` has always excluded the token, so authenticated clients must include their authorization when connecting to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DevTools and WebSocket URLs now work correctly with external addresses and authentication tokens.
  * Session and browser-list responses include token-authorized connection URLs when required.
  * Special characters in authentication tokens are safely encoded.

* **Security**
  * Sensitive tokens are redacted from request and access logs.
  * Unauthorized page WebSocket connections are consistently rejected.

* **Documentation**
  * Updated API guidance to identify credential-bearing DevTools URLs and recommend redacting query strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->