### PR TITLE
feat(PLT-1402): accept blockAdsInclude in REST schemas

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -183,15 +183,7 @@ export interface SystemQueryParameters {
    */
   blockAds?: boolean;
 
-  /**
-   * When `blockAds` is enabled, restricts ad-blocking to the named uBlock
-   * ruleset ids instead of loading the full ruleset set. Fewer rulesets means
-   * a faster cold launch. Ignored when `blockAds` is false.
-   *
-   * Accepts a comma-separated list (`easylist,ublock-filters`) or JSON-array
-   * text (`["easylist"]`), matching the parameter's existing behaviour on
-   * `/pdf`, `/screenshot`, `/chromium/unblock`, BQL and the connect routes.
-   */
+  /** Ruleset IDs to load when `blockAds` is enabled, as CSV or JSON-array text. */
   blockAdsInclude?: string;
 
   /**

--- a/src/http.ts
+++ b/src/http.ts
@@ -184,6 +184,17 @@ export interface SystemQueryParameters {
   blockAds?: boolean;
 
   /**
+   * When `blockAds` is enabled, restricts ad-blocking to the named uBlock
+   * ruleset ids instead of loading the full ruleset set. Fewer rulesets means
+   * a faster cold launch. Ignored when `blockAds` is false.
+   *
+   * Accepts a comma-separated list (`easylist,ublock-filters`) or JSON-array
+   * text (`["easylist"]`), matching the parameter's existing behaviour on
+   * `/pdf`, `/screenshot`, `/chromium/unblock`, BQL and the connect routes.
+   */
+  blockAdsInclude?: string;
+
+  /**
    * Launch options, which can be either an object
    * of puppeteer.launch options or playwright.launchServer
    * options, depending on the API. Must be either JSON

--- a/src/shared/tests/schema-coercion-parity.spec.ts
+++ b/src/shared/tests/schema-coercion-parity.spec.ts
@@ -1,15 +1,13 @@
 import { expect } from 'chai';
-import { execFile } from 'child_process';
+import { execFileSync } from 'child_process';
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { promisify } from 'util';
 
 import { compileSchema } from '../utils/schema-validator.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const routes = path.resolve(__dirname, '../../routes/chromium/http');
-const execFileAsync = promisify(execFile);
 
 /**
  * Locks in the coercion contract that matches joi+enjoi (the previous validator).
@@ -26,7 +24,7 @@ describe('Schema coercion parity (joi+enjoi → ajv)', function () {
   // Single-browser docker images don't ship chromium route schemas;
   // skip the suite in that case so firefox/webkit/edge CI doesn't choke.
   before(async function () {
-    await execFileAsync(process.execPath, ['scripts/build-schemas.js']);
+    execFileSync(process.execPath, ['scripts/build-schemas.js']);
 
     try {
       await fs.access(path.join(routes, 'pdf.post.body.json'));

--- a/src/shared/tests/schema-coercion-parity.spec.ts
+++ b/src/shared/tests/schema-coercion-parity.spec.ts
@@ -1,12 +1,15 @@
 import { expect } from 'chai';
+import { execFile } from 'child_process';
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { promisify } from 'util';
 
 import { compileSchema } from '../utils/schema-validator.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const routes = path.resolve(__dirname, '../../routes/chromium/http');
+const execFileAsync = promisify(execFile);
 
 /**
  * Locks in the coercion contract that matches joi+enjoi (the previous validator).
@@ -23,6 +26,8 @@ describe('Schema coercion parity (joi+enjoi → ajv)', function () {
   // Single-browser docker images don't ship chromium route schemas;
   // skip the suite in that case so firefox/webkit/edge CI doesn't choke.
   before(async function () {
+    await execFileAsync(process.execPath, ['scripts/build-schemas.js']);
+
     try {
       await fs.access(path.join(routes, 'pdf.post.body.json'));
     } catch {

--- a/src/shared/tests/schema-coercion-parity.spec.ts
+++ b/src/shared/tests/schema-coercion-parity.spec.ts
@@ -141,6 +141,25 @@ describe('Schema coercion parity (joi+enjoi → ajv)', function () {
     expect(v.launch).to.equal(encoded);
   });
 
+  it('accepts scalar blockAdsInclude while keeping route query schemas strict', async function () {
+    const schema = compileSchema(await loadSchema('content.post.query.json'));
+
+    const accepted = schema.validate({
+      blockAds: 'true',
+      blockAdsInclude: 'easylist,ublock-filters',
+    });
+    expect(accepted.error, accepted.error?.message).to.be.undefined;
+    expect(accepted.value).to.deep.include({
+      blockAds: true,
+      blockAdsInclude: 'easylist,ublock-filters',
+    });
+
+    const rejected = schema.validate({ definitelyNotAParam: '1' });
+    expect(rejected.error?.message).to.include(
+      'must NOT have additional properties',
+    );
+  });
+
   // Joi rejects empty strings for boolean fields; the prior implementation accidentally
   // coerced "" -> true. Lock the rejection in so the bug cannot regress.
   it('rejects empty string for a nested boolean field', async function () {


### PR DESCRIPTION
## Summary

- Add optional scalar `blockAdsInclude` support to the shared REST query contract.
- Regenerate route schemas in the parity suite and prove scalar/CSV acceptance without weakening unknown-parameter rejection.
- Keep OSS runtime behavior inert; Enterprise will consume the published package in the second dependency-ordered PR.

## Assumptions made

- The approved public wire contract is a scalar string; CSV and JSON-array text parsing remains in Enterprise.
- Generated route schemas are build artifacts and are not committed.
- The local Docker listener on IPv4 `127.0.0.1:3000` can coexist with host tests on IPv6 `::1:3000`; the stack was left running.

## Testing

- `npm run build`
- `npm test -- --grep 'Schema coercion parity'` — 17 passing
- `npm test` — 681 passing, 3 pending, exit 0

## Release dependency

After this PR is merged and the package is published, resume PLT-1402 in Enterprise with an exact package version, the five-route launch plumbing, validation coverage, local-stack E2E, and the Enterprise host suite. This PR does not complete the ticket.

🤖 Built with the /implement-plan skill from PLT-1402.md

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying ad-blocking ruleset IDs through the `blockAdsInclude` query parameter.
  * Ruleset IDs can be provided as comma-separated text or a JSON array when ad blocking is enabled.

* **Bug Fixes**
  * Improved query validation to accept supported ad-blocking parameters while continuing to reject unknown parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->