### PR TITLE
fix(deps): bump puppeteer-core to 25.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "playwright-1.60": "npm:playwright-core@1.60.0",
         "playwright-1.61": "npm:playwright-core@1.61.1",
         "playwright-core": "1.62.1",
-        "puppeteer-core": "25.5.0",
+        "puppeteer-core": "25.7.0",
         "queue": "^7.0.0",
         "systeminformation": "^5.33.1",
         "tar-fs": "^3.1.3",
@@ -1017,12 +1017,12 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.1.0.tgz",
-      "integrity": "sha512-RDLpio3fH/qrj5k4DVY6eyiN8tCS0Zovd/6jW//n605oeqkWcUjn+3k+9ZtZBnbwMpsu0F7xDIiKXvVmG5c5Bw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.0.tgz",
+      "integrity": "sha512-LlBrE8oqGfU7b1Nk2d5Q1SbuPhZxTj0cJEMDPEws28OjNMELlflekmPPuf4FnK03x0ZRjKaYwJElUcKK4kyqJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "modern-tar": "^0.7.6",
+        "modern-tar": "^0.8.0",
         "yargs": "^18.0.0"
       },
       "bin": {
@@ -1045,9 +1045,9 @@
       }
     },
     "node_modules/@puppeteer/browsers/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4299,9 +4299,9 @@
       }
     },
     "node_modules/modern-tar": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.7.tgz",
-      "integrity": "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.8.4.tgz",
+      "integrity": "sha512-gN54ddmyzEg10orwZ2u4OOv+bjpMWdIl5jIkodK97bMq8QBSL5c0D7YX0lT1Ooz+99S7+PvFbnxzdjgHo1r41g==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -4680,14 +4680,14 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.5.0.tgz",
-      "integrity": "sha512-XPNT0dQJtphqQ4I29zxlG4IIPbg1iEHAQKWuQgtMJGXjACV77pZSmJvDi51IIIfd+DTKICcopJwUx4upVQ4XbA==",
+      "version": "25.7.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.7.0.tgz",
+      "integrity": "sha512-wgBBj7dU5ceGyoT2PCrJpkYOhxPY8mDOmcSKZP92Cj5GgqQ3kv/UxzawnOLxiYuupe4bDf/yiQm3bzs/1nI0rQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "3.1.0",
+        "@puppeteer/browsers": "3.2.0",
         "chromium-bidi": "17.0.2",
-        "devtools-protocol": "0.0.1653615",
+        "devtools-protocol": "0.0.1666840",
         "typed-query-selector": "^2.12.2",
         "webdriver-bidi-protocol": "0.4.2",
         "ws": "^8.21.1"
@@ -4697,9 +4697,9 @@
       }
     },
     "node_modules/puppeteer-core/node_modules/devtools-protocol": {
-      "version": "0.0.1653615",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1653615.tgz",
-      "integrity": "sha512-pGVkY3T/qXxAp2nFPodwYqOevk6ncNMSmvL8QfRCx5ZWGd6Vor7AFNmyaA8Zs6uJyP1QAfjuLandCgvSix1BNA==",
+      "version": "0.0.1666840",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1666840.tgz",
+      "integrity": "sha512-gCcO42XCHKEs7Ag0S7aGYsnJ7hlgrO3qderYqeiY0Eqk+0GFfuvT13IA0hHreJTa2KCdDVyGMeOhdMNmrrTjVg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/puppeteer-core/node_modules/webdriver-bidi-protocol": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "playwright-1.60": "npm:playwright-core@1.60.0",
     "playwright-1.61": "npm:playwright-core@1.61.1",
     "playwright-core": "1.62.1",
-    "puppeteer-core": "25.5.0",
+    "puppeteer-core": "25.7.0",
     "queue": "^7.0.0",
     "systeminformation": "^5.33.1",
     "tar-fs": "^3.1.3",

--- a/src/routes/chrome/tests/page-websocket.spec.ts
+++ b/src/routes/chrome/tests/page-websocket.spec.ts
@@ -3,16 +3,24 @@ import puppeteer from 'puppeteer-core';
 import { WebSocket } from 'ws';
 import { expect } from 'chai';
 
-// Sends a single CDP command over a raw WebSocket, resolving with the
-// response, or rejecting when the connection can't be established.
+// Sends a single CDP command over a raw WebSocket, resolving with the response
+// to that command, or rejecting when the connection can't be established. The
+// page proxy also forwards CDP events, so responses are matched on their id.
 const cdpSend = (url: string, method: string) =>
   new Promise((resolve, reject) => {
     const ws = new WebSocket(url);
     ws.once('error', reject);
     ws.once('open', () => ws.send(JSON.stringify({ id: 1, method })));
-    ws.once('message', (data) => {
-      ws.close();
-      resolve(JSON.parse(data.toString()));
+    ws.on('message', (data) => {
+      try {
+        const message = JSON.parse(data.toString());
+        if (message.id !== 1) return;
+        ws.close();
+        resolve(message);
+      } catch (err: unknown) {
+        ws.close();
+        reject(err);
+      }
     });
   });
 

--- a/src/routes/chrome/tests/page-websocket.spec.ts
+++ b/src/routes/chrome/tests/page-websocket.spec.ts
@@ -1,8 +1,20 @@
 import { Browserless, Config, Metrics } from '@browserless.io/browserless';
 import puppeteer from 'puppeteer-core';
-import { Connection } from 'puppeteer-core/internal/cdp/Connection.js';
-import { NodeWebSocketTransport } from 'puppeteer-core/internal/node/NodeWebSocketTransport.js';
+import { WebSocket } from 'ws';
 import { expect } from 'chai';
+
+// Sends a single CDP command over a raw WebSocket, resolving with the
+// response, or rejecting when the connection can't be established.
+const cdpSend = (url: string, method: string) =>
+  new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    ws.once('error', reject);
+    ws.once('open', () => ws.send(JSON.stringify({ id: 1, method })));
+    ws.once('message', (data) => {
+      ws.close();
+      resolve(JSON.parse(data.toString()));
+    });
+  });
 
 describe('WebSocket Page API', function () {
   let browserless: Browserless;
@@ -33,14 +45,8 @@ describe('WebSocket Page API', function () {
     const pageId = page.target()._targetId;
     const webSocketDebuggerUrl = `ws://localhost:3000/devtools/page/${pageId}`;
 
-    // Connect to raw page target
-    const cdp = new Connection(
-      webSocketDebuggerUrl,
-      await NodeWebSocketTransport.create(webSocketDebuggerUrl),
-    );
-
-    // Send a command
-    const result = await cdp.send('Page.enable');
+    // Connect to raw page target and send a command
+    const result = await cdpSend(webSocketDebuggerUrl, 'Page.enable');
     await browser.close();
     expect(result);
   });
@@ -57,15 +63,8 @@ describe('WebSocket Page API', function () {
       },
     ).then((r) => r.json());
 
-    // Connect to raw page target
-    const cdp = new Connection(
-      webSocketDebuggerUrl,
-      await NodeWebSocketTransport.create(webSocketDebuggerUrl),
-    );
-
-    // Send a command
-    const result = await cdp.send('Page.enable');
-    cdp.dispose();
+    // Connect to raw page target and send a command
+    const result = await cdpSend(webSocketDebuggerUrl, 'Page.enable');
     expect(result);
   });
 
@@ -86,10 +85,7 @@ describe('WebSocket Page API', function () {
 
     // Connect to raw page target without authorization
     try {
-      new Connection(
-        webSocketDebuggerUrl,
-        await NodeWebSocketTransport.create(webSocketDebuggerUrl),
-      );
+      await cdpSend(webSocketDebuggerUrl, 'Page.enable');
     } catch (err: unknown) {
       //@ts-ignore
       expect(err.message).to.include('401');
@@ -112,10 +108,7 @@ describe('WebSocket Page API', function () {
 
     // Connect to raw page target without authorization
     try {
-      new Connection(
-        webSocketDebuggerUrl,
-        await NodeWebSocketTransport.create(webSocketDebuggerUrl),
-      );
+      await cdpSend(webSocketDebuggerUrl, 'Page.enable');
     } catch (err: unknown) {
       //@ts-ignore
       expect(err.message).to.include('404');

--- a/src/routes/chromium/tests/page-websocket.spec.ts
+++ b/src/routes/chromium/tests/page-websocket.spec.ts
@@ -3,16 +3,24 @@ import puppeteer from 'puppeteer-core';
 import { WebSocket } from 'ws';
 import { expect } from 'chai';
 
-// Sends a single CDP command over a raw WebSocket, resolving with the
-// response, or rejecting when the connection can't be established.
+// Sends a single CDP command over a raw WebSocket, resolving with the response
+// to that command, or rejecting when the connection can't be established. The
+// page proxy also forwards CDP events, so responses are matched on their id.
 const cdpSend = (url: string, method: string) =>
   new Promise((resolve, reject) => {
     const ws = new WebSocket(url);
     ws.once('error', reject);
     ws.once('open', () => ws.send(JSON.stringify({ id: 1, method })));
-    ws.once('message', (data) => {
-      ws.close();
-      resolve(JSON.parse(data.toString()));
+    ws.on('message', (data) => {
+      try {
+        const message = JSON.parse(data.toString());
+        if (message.id !== 1) return;
+        ws.close();
+        resolve(message);
+      } catch (err: unknown) {
+        ws.close();
+        reject(err);
+      }
     });
   });
 

--- a/src/routes/chromium/tests/page-websocket.spec.ts
+++ b/src/routes/chromium/tests/page-websocket.spec.ts
@@ -1,8 +1,20 @@
 import { Browserless, Config, Metrics } from '@browserless.io/browserless';
 import puppeteer from 'puppeteer-core';
-import { Connection } from 'puppeteer-core/internal/cdp/Connection.js';
-import { NodeWebSocketTransport } from 'puppeteer-core/internal/node/NodeWebSocketTransport.js';
+import { WebSocket } from 'ws';
 import { expect } from 'chai';
+
+// Sends a single CDP command over a raw WebSocket, resolving with the
+// response, or rejecting when the connection can't be established.
+const cdpSend = (url: string, method: string) =>
+  new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    ws.once('error', reject);
+    ws.once('open', () => ws.send(JSON.stringify({ id: 1, method })));
+    ws.once('message', (data) => {
+      ws.close();
+      resolve(JSON.parse(data.toString()));
+    });
+  });
 
 describe('WebSocket Page API', function () {
   let browserless: Browserless;
@@ -33,14 +45,8 @@ describe('WebSocket Page API', function () {
     const pageId = page.target()._targetId;
     const webSocketDebuggerUrl = `ws://localhost:3000/devtools/page/${pageId}`;
 
-    // Connect to raw page target
-    const cdp = new Connection(
-      webSocketDebuggerUrl,
-      await NodeWebSocketTransport.create(webSocketDebuggerUrl),
-    );
-
-    // Send a command
-    const result = await cdp.send('Page.enable');
+    // Connect to raw page target and send a command
+    const result = await cdpSend(webSocketDebuggerUrl, 'Page.enable');
     await browser.close();
     expect(result);
   });
@@ -57,15 +63,8 @@ describe('WebSocket Page API', function () {
       },
     ).then((r) => r.json());
 
-    // Connect to raw page target
-    const cdp = new Connection(
-      webSocketDebuggerUrl,
-      await NodeWebSocketTransport.create(webSocketDebuggerUrl),
-    );
-
-    // Send a command
-    const result = await cdp.send('Page.enable');
-    cdp.dispose();
+    // Connect to raw page target and send a command
+    const result = await cdpSend(webSocketDebuggerUrl, 'Page.enable');
     expect(result);
   });
 
@@ -86,10 +85,7 @@ describe('WebSocket Page API', function () {
 
     // Connect to raw page target without authorization
     try {
-      new Connection(
-        webSocketDebuggerUrl,
-        await NodeWebSocketTransport.create(webSocketDebuggerUrl),
-      );
+      await cdpSend(webSocketDebuggerUrl, 'Page.enable');
     } catch (err: unknown) {
       //@ts-ignore
       expect(err.message).to.include('401');
@@ -112,10 +108,7 @@ describe('WebSocket Page API', function () {
 
     // Connect to raw page target without authorization
     try {
-      new Connection(
-        webSocketDebuggerUrl,
-        await NodeWebSocketTransport.create(webSocketDebuggerUrl),
-      );
+      await cdpSend(webSocketDebuggerUrl, 'Page.enable');
     } catch (err: unknown) {
       //@ts-ignore
       expect(err.message).to.include('404');

--- a/src/routes/edge/tests/page-websocket.spec.ts
+++ b/src/routes/edge/tests/page-websocket.spec.ts
@@ -3,16 +3,24 @@ import puppeteer from 'puppeteer-core';
 import { WebSocket } from 'ws';
 import { expect } from 'chai';
 
-// Sends a single CDP command over a raw WebSocket, resolving with the
-// response, or rejecting when the connection can't be established.
+// Sends a single CDP command over a raw WebSocket, resolving with the response
+// to that command, or rejecting when the connection can't be established. The
+// page proxy also forwards CDP events, so responses are matched on their id.
 const cdpSend = (url: string, method: string) =>
   new Promise((resolve, reject) => {
     const ws = new WebSocket(url);
     ws.once('error', reject);
     ws.once('open', () => ws.send(JSON.stringify({ id: 1, method })));
-    ws.once('message', (data) => {
-      ws.close();
-      resolve(JSON.parse(data.toString()));
+    ws.on('message', (data) => {
+      try {
+        const message = JSON.parse(data.toString());
+        if (message.id !== 1) return;
+        ws.close();
+        resolve(message);
+      } catch (err: unknown) {
+        ws.close();
+        reject(err);
+      }
     });
   });
 

--- a/src/routes/edge/tests/page-websocket.spec.ts
+++ b/src/routes/edge/tests/page-websocket.spec.ts
@@ -1,8 +1,20 @@
 import { Browserless, Config, Metrics } from '@browserless.io/browserless';
 import puppeteer from 'puppeteer-core';
-import { Connection } from 'puppeteer-core/internal/cdp/Connection.js';
-import { NodeWebSocketTransport } from 'puppeteer-core/internal/node/NodeWebSocketTransport.js';
+import { WebSocket } from 'ws';
 import { expect } from 'chai';
+
+// Sends a single CDP command over a raw WebSocket, resolving with the
+// response, or rejecting when the connection can't be established.
+const cdpSend = (url: string, method: string) =>
+  new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    ws.once('error', reject);
+    ws.once('open', () => ws.send(JSON.stringify({ id: 1, method })));
+    ws.once('message', (data) => {
+      ws.close();
+      resolve(JSON.parse(data.toString()));
+    });
+  });
 
 describe('WebSocket Page API', function () {
   let browserless: Browserless;
@@ -33,14 +45,8 @@ describe('WebSocket Page API', function () {
     const pageId = page.target()._targetId;
     const webSocketDebuggerUrl = `ws://localhost:3000/devtools/page/${pageId}`;
 
-    // Connect to raw page target
-    const cdp = new Connection(
-      webSocketDebuggerUrl,
-      await NodeWebSocketTransport.create(webSocketDebuggerUrl),
-    );
-
-    // Send a command
-    const result = await cdp.send('Page.enable');
+    // Connect to raw page target and send a command
+    const result = await cdpSend(webSocketDebuggerUrl, 'Page.enable');
     await browser.close();
     expect(result);
   });
@@ -57,15 +63,8 @@ describe('WebSocket Page API', function () {
       },
     ).then((r) => r.json());
 
-    // Connect to raw page target
-    const cdp = new Connection(
-      webSocketDebuggerUrl,
-      await NodeWebSocketTransport.create(webSocketDebuggerUrl),
-    );
-
-    // Send a command
-    const result = await cdp.send('Page.enable');
-    cdp.dispose();
+    // Connect to raw page target and send a command
+    const result = await cdpSend(webSocketDebuggerUrl, 'Page.enable');
     expect(result);
   });
 
@@ -86,10 +85,7 @@ describe('WebSocket Page API', function () {
 
     // Connect to raw page target without authorization
     try {
-      new Connection(
-        webSocketDebuggerUrl,
-        await NodeWebSocketTransport.create(webSocketDebuggerUrl),
-      );
+      await cdpSend(webSocketDebuggerUrl, 'Page.enable');
     } catch (err: unknown) {
       //@ts-ignore
       expect(err.message).to.include('401');
@@ -112,10 +108,7 @@ describe('WebSocket Page API', function () {
 
     // Connect to raw page target without authorization
     try {
-      new Connection(
-        webSocketDebuggerUrl,
-        await NodeWebSocketTransport.create(webSocketDebuggerUrl),
-      );
+      await cdpSend(webSocketDebuggerUrl, 'Page.enable');
     } catch (err: unknown) {
       //@ts-ignore
       expect(err.message).to.include('404');

--- a/src/shared/utils/function/client.ts
+++ b/src/shared/utils/function/client.ts
@@ -7,6 +7,9 @@ type codeHandler = (params: {
   page: Page;
 }) => Promise<unknown>;
 
+// puppeteer-core >= 25.6 requires an explicit Logger on these internals.
+const logger = () => undefined;
+
 export class FunctionRunner {
   protected browser?: Browser;
   protected page?: Page;
@@ -26,8 +29,11 @@ export class FunctionRunner {
   }) {
     console.log(`/function.js: Got endpoint: "${data.browserWSEndpoint}"`);
     const { browserWSEndpoint, code, context, options } = data;
-    const connectionTransport =
-      await BrowserWebSocketTransport.create(browserWSEndpoint);
+    const connectionTransport = await BrowserWebSocketTransport.create(
+      browserWSEndpoint,
+      undefined,
+      logger,
+    );
     const cdpOptions = {
       headers: {
         Host: '127.0.0.1',
@@ -39,6 +45,7 @@ export class FunctionRunner {
       connectionTransport,
       browserWSEndpoint,
       cdpOptions,
+      logger,
     )) as unknown as Browser;
     this.browser.once('disconnected', () => this.stop());
     this.page = await this.browser.newPage();


### PR DESCRIPTION
Replaces #5543, which failed CI: the bump alone does not compile.

## Why #5543 failed

`puppeteer-core` 25.6.0 ([#15297](https://github.com/puppeteer/puppeteer/pull/15297), [#15302](https://github.com/puppeteer/puppeteer/pull/15302) — "pass logger through the constructors") turned `logger` into a **required** trailing parameter on the `@internal` APIs this repo imports:

```ts
BrowserWebSocketTransport.create(url, headers, logger)
NodeWebSocketTransport.create(url, headers, logger)
_connectToCdpBrowser(transport, url, options, logger)
new Connection(url, transport, delay, timeout, rawErrors, idGenerator, logger)
```

`tsc` therefore fails inside the Docker builder stage, so every `test-*` job plus `leak-check` dies before a single test runs:

```
src/shared/utils/function/client.ts(30,39): error TS2554: Expected 3 arguments, but got 1.
src/shared/utils/function/client.ts(38,27): error TS2554: Expected 4 arguments, but got 3.
src/routes/{chrome,chromium,edge}/tests/page-websocket.spec.ts: error TS2554: Expected 7 arguments, but got 2.
```

## What this PR does

**`src/shared/utils/function/client.ts`** — keeps the internal CDP connector (this file is esbuild-bundled for the browser via `scripts/build-function.js`, so the public `puppeteer.connect` would drag in the Node launcher) and passes an explicit no-op logger.

**`src/routes/{chrome,chromium,edge}/tests/page-websocket.spec.ts`** — drops the `puppeteer-core/internal` imports in favour of a raw `ws` connection. These specs only assert that `/devtools/page/:id` proxies a single CDP command and rejects with 401/404, which a plain WebSocket covers without the 7-argument `Connection` constructor. `ws` is already a direct dependency.

The alternative was to thread a logger through all 12 `new Connection(...)` call sites. Not worth it: these internals have now broken twice in three minor releases — 25.5.0 removed the public `Connection` export (#5535 moved the import to `puppeteer-core/internal/cdp/Connection.js`), 25.6.0 added the required logger. Test assertions are unchanged.

## Also in this bump

Chrome rolls 151.0.7922.77 → **152.0.7977.42**, Firefox → 153.0.4, `@puppeteer/browsers` 3.1.0 → 3.2.0. No Chrome revision is pinned in this repo, so the images pick the new build up automatically.

## Verification

- `npm run build:ts` — clean
- `npm run build:function` — browser bundle builds
- `npx prettier --check` on the touched files — clean
- `WebSocket Page API` specs (chromium, locally): all 4 pass — forwards requests to running pages, `/json/new`, 401, 404

Commit is typed `fix(deps):` so release-please cuts a patch release once this lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of browser page WebSocket interactions, including unauthorized and unavailable page scenarios.
  * Prevented unnecessary internal browser automation logs from appearing.

* **Tests**
  * Updated WebSocket coverage to validate connection responses, successful commands, and error handling more consistently across supported browsers.

* **Chores**
  * Updated the browser automation component to a newer version for improved compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->