### PR TITLE
fix: close function pages when user code fails

### DIFF
--- a/src/shared/utils/function/client.spec.ts
+++ b/src/shared/utils/function/client.spec.ts
@@ -26,9 +26,19 @@ describe('FunctionRunner', function () {
 
   it('closes the page before disconnecting when user code rejects', async () => {
     const calls: string[] = [];
+    let finishClose = () => {};
+    let markCloseStarted = () => {};
+    const close = new Promise<void>((resolve) => {
+      finishClose = resolve;
+    });
+    const closeStarted = new Promise<void>((resolve) => {
+      markCloseStarted = resolve;
+    });
     const page = {
-      close: Sinon.stub().callsFake(async () => {
+      close: Sinon.stub().callsFake(() => {
         calls.push('close');
+        markCloseStarted();
+        return close;
       }),
     } as unknown as Page;
     const browser = {
@@ -40,17 +50,65 @@ describe('FunctionRunner', function () {
     runner.setBrowser(browser);
     Sinon.stub(console, 'error');
 
-    let thrown: unknown;
-    try {
-      await runner.execute(async () => {
+    const execution = runner
+      .execute(async () => {
         throw error;
-      }, {});
-    } catch (caught) {
-      thrown = caught;
-    }
+      }, {})
+      .catch((caught) => caught);
+    await closeStarted;
+
+    expect(calls).to.deep.equal(['close']);
+    finishClose();
+
+    expect(await execution).to.equal(error);
+    expect(calls).to.deep.equal(['close', 'disconnect']);
+  });
+
+  it('cleans up when user code throws synchronously', async () => {
+    const close = Sinon.stub().resolves();
+    const disconnect = Sinon.stub();
+    const page = { close } as unknown as Page;
+    const browser = { disconnect } as unknown as Browser;
+    const runner = new TestFunctionRunner();
+    const error = new Error('synchronous user error');
+    runner.setPage(page);
+    runner.setBrowser(browser);
+    Sinon.stub(console, 'error');
+
+    const thrown = await runner
+      .execute(() => {
+        throw error;
+      }, {})
+      .catch((caught) => caught);
 
     expect(thrown).to.equal(error);
-    expect(calls).to.deep.equal(['close', 'disconnect']);
+    expect(close.calledOnce).to.be.true;
+    expect(disconnect.calledOnce).to.be.true;
+  });
+
+  it('preserves the user error when closing the page fails', async () => {
+    const closeError = new Error('page close failed');
+    const close = Sinon.stub().rejects(closeError);
+    const disconnect = Sinon.stub();
+    const page = { close } as unknown as Page;
+    const browser = { disconnect } as unknown as Browser;
+    const runner = new TestFunctionRunner();
+    const userError = new Error('user code failed');
+    const log = Sinon.stub(console, 'error');
+    runner.setPage(page);
+    runner.setBrowser(browser);
+
+    const thrown = await runner
+      .execute(async () => {
+        throw userError;
+      }, {})
+      .catch((caught) => caught);
+
+    expect(thrown).to.equal(userError);
+    expect(close.calledOnce).to.be.true;
+    expect(disconnect.calledOnce).to.be.true;
+    expect(log.calledWith(`_browserless_function_client_: ${closeError}`)).to.be
+      .true;
   });
 
   it('logs errors when passed as an unbound rejection handler', async () => {

--- a/src/shared/utils/function/client.spec.ts
+++ b/src/shared/utils/function/client.spec.ts
@@ -5,27 +5,22 @@ import Sinon from 'sinon';
 import { FunctionRunner } from './client.js';
 
 class TestFunctionRunner extends FunctionRunner {
-  public setBrowser(browser: Browser): void {
-    this.browser = browser;
-  }
-
-  public setPage(page: Page): void {
-    this.page = page;
-  }
-
-  public execute(
+  public async execute(
+    browser: Browser,
     code: Parameters<FunctionRunner['start']>[0]['code'],
-    context: unknown,
+    context: unknown = {},
+    options: Parameters<FunctionRunner['start']>[0]['options'] = {},
   ): Promise<unknown> {
-    return this.runCode(code, context);
+    this.browser = browser;
+    return this.runWithBrowser(code, context, options);
   }
 }
 
 describe('FunctionRunner', function () {
+  beforeEach(() => Sinon.stub(console, 'debug'));
   afterEach(() => Sinon.restore());
 
-  it('closes the page before disconnecting when user code rejects', async () => {
-    const calls: string[] = [];
+  it('waits for the inner page to close before returning success', async () => {
     let finishClose = () => {};
     let markCloseStarted = () => {};
     const close = new Promise<void>((resolve) => {
@@ -36,79 +31,138 @@ describe('FunctionRunner', function () {
     });
     const page = {
       close: Sinon.stub().callsFake(() => {
-        calls.push('close');
         markCloseStarted();
         return close;
       }),
     } as unknown as Page;
     const browser = {
-      disconnect: Sinon.stub().callsFake(() => calls.push('disconnect')),
+      disconnect: Sinon.stub(),
+      newPage: Sinon.stub().resolves(page),
     } as unknown as Browser;
     const runner = new TestFunctionRunner();
-    const error = new Error('user code failed');
-    runner.setPage(page);
-    runner.setBrowser(browser);
+    let settled = false;
+
+    const execution = runner
+      .execute(browser, async () => 'done')
+      .then((result) => {
+        settled = true;
+        return result;
+      });
+    await closeStarted;
+
+    expect(settled).to.be.false;
+    finishClose();
+
+    expect(await execution).to.deep.equal({
+      contentType: 'text/plain',
+      payload: 'done',
+    });
+    expect((browser.disconnect as Sinon.SinonStub).called).to.be.false;
+  });
+
+  it('cleans up when download setup fails after creating a page', async () => {
+    const setupError = new Error('download setup failed');
+    const close = Sinon.stub().resolves();
+    const disconnect = Sinon.stub();
+    const page = {
+      _client: {
+        call: () => ({ send: Sinon.stub().rejects(setupError) }),
+      },
+      close,
+    } as unknown as Page;
+    const browser = {
+      disconnect,
+      newPage: Sinon.stub().resolves(page),
+    } as unknown as Browser;
+    const runner = new TestFunctionRunner();
+
+    const thrown = await runner
+      .execute(browser, async () => undefined, {}, { downloadPath: '/tmp' })
+      .catch((caught) => caught);
+
+    expect(thrown).to.equal(setupError);
+    expect(close.calledOnce).to.be.true;
+    expect(disconnect.calledOnce).to.be.true;
+  });
+
+  it('bounds page cleanup and preserves the user error', async () => {
+    const clock = Sinon.useFakeTimers();
+    const close = Sinon.stub().returns(new Promise<void>(() => {}));
+    const disconnect = Sinon.stub();
+    const page = { close } as unknown as Page;
+    const browser = {
+      disconnect,
+      newPage: Sinon.stub().resolves(page),
+    } as unknown as Browser;
+    const runner = new TestFunctionRunner();
+    const userError = new Error('user code failed');
     Sinon.stub(console, 'error');
 
     const execution = runner
-      .execute(async () => {
-        throw error;
-      }, {})
+      .execute(browser, async () => {
+        throw userError;
+      })
       .catch((caught) => caught);
-    await closeStarted;
+    await clock.tickAsync(2_000);
 
-    expect(calls).to.deep.equal(['close']);
-    finishClose();
-
-    expect(await execution).to.equal(error);
-    expect(calls).to.deep.equal(['close', 'disconnect']);
-  });
-
-  it('cleans up when user code throws synchronously', async () => {
-    const close = Sinon.stub().resolves();
-    const disconnect = Sinon.stub();
-    const page = { close } as unknown as Page;
-    const browser = { disconnect } as unknown as Browser;
-    const runner = new TestFunctionRunner();
-    const error = new Error('synchronous user error');
-    runner.setPage(page);
-    runner.setBrowser(browser);
-    Sinon.stub(console, 'error');
-
-    const thrown = await runner
-      .execute(() => {
-        throw error;
-      }, {})
-      .catch((caught) => caught);
-
-    expect(thrown).to.equal(error);
+    expect(await execution).to.equal(userError);
     expect(close.calledOnce).to.be.true;
     expect(disconnect.calledOnce).to.be.true;
   });
 
-  it('preserves the user error when closing the page fails', async () => {
-    const closeError = new Error('page close failed');
-    const close = Sinon.stub().rejects(closeError);
-    const disconnect = Sinon.stub();
-    const page = { close } as unknown as Page;
-    const browser = { disconnect } as unknown as Browser;
+  for (const asynchronous of [false, true]) {
+    it(`preserves ${asynchronous ? 'asynchronous' : 'synchronous'} user errors when closing fails`, async () => {
+      const closeError = new Error('page close failed');
+      const close = Sinon.stub().rejects(closeError);
+      const disconnect = Sinon.stub();
+      const page = { close } as unknown as Page;
+      const browser = {
+        disconnect,
+        newPage: Sinon.stub().resolves(page),
+      } as unknown as Browser;
+      const runner = new TestFunctionRunner();
+      const userError = new Error('user code failed');
+      const log = Sinon.stub(console, 'error');
+      const code = asynchronous
+        ? async () => {
+            throw userError;
+          }
+        : () => {
+            throw userError;
+          };
+
+      const thrown = await runner
+        .execute(browser, code)
+        .catch((caught) => caught);
+
+      expect(thrown).to.equal(userError);
+      expect(close.calledOnce).to.be.true;
+      expect(disconnect.calledOnce).to.be.true;
+      expect(log.calledWith(`_browserless_function_client_: ${closeError}`)).to
+        .be.true;
+    });
+  }
+
+  it('preserves the user error when disconnecting fails', async () => {
+    const disconnectError = new Error('disconnect failed');
+    const page = { close: Sinon.stub().resolves() } as unknown as Page;
+    const browser = {
+      disconnect: Sinon.stub().throws(disconnectError),
+      newPage: Sinon.stub().resolves(page),
+    } as unknown as Browser;
     const runner = new TestFunctionRunner();
     const userError = new Error('user code failed');
     const log = Sinon.stub(console, 'error');
-    runner.setPage(page);
-    runner.setBrowser(browser);
 
     const thrown = await runner
-      .execute(async () => {
+      .execute(browser, async () => {
         throw userError;
-      }, {})
+      })
       .catch((caught) => caught);
 
     expect(thrown).to.equal(userError);
-    expect(close.calledOnce).to.be.true;
-    expect(disconnect.calledOnce).to.be.true;
-    expect(log.calledWith(`_browserless_function_client_: ${closeError}`)).to.be
-      .true;
+    expect(log.calledWith(`_browserless_function_client_: ${disconnectError}`))
+      .to.be.true;
   });
 
   it('logs errors when passed as an unbound rejection handler', async () => {

--- a/src/shared/utils/function/client.spec.ts
+++ b/src/shared/utils/function/client.spec.ts
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+import type { Browser, Page } from 'puppeteer-core';
+import Sinon from 'sinon';
+
+import { FunctionRunner } from './client.js';
+
+class TestFunctionRunner extends FunctionRunner {
+  public setBrowser(browser: Browser): void {
+    this.browser = browser;
+  }
+
+  public setPage(page: Page): void {
+    this.page = page;
+  }
+
+  public execute(
+    code: Parameters<FunctionRunner['start']>[0]['code'],
+    context: unknown,
+  ): Promise<unknown> {
+    return this.runCode(code, context);
+  }
+}
+
+describe('FunctionRunner', function () {
+  afterEach(() => Sinon.restore());
+
+  it('closes the page before disconnecting when user code rejects', async () => {
+    const calls: string[] = [];
+    const page = {
+      close: Sinon.stub().callsFake(async () => {
+        calls.push('close');
+      }),
+    } as unknown as Page;
+    const browser = {
+      disconnect: Sinon.stub().callsFake(() => calls.push('disconnect')),
+    } as unknown as Browser;
+    const runner = new TestFunctionRunner();
+    const error = new Error('user code failed');
+    runner.setPage(page);
+    runner.setBrowser(browser);
+    Sinon.stub(console, 'error');
+
+    let thrown: unknown;
+    try {
+      await runner.execute(async () => {
+        throw error;
+      }, {});
+    } catch (caught) {
+      thrown = caught;
+    }
+
+    expect(thrown).to.equal(error);
+    expect(calls).to.deep.equal(['close', 'disconnect']);
+  });
+
+  it('logs errors when passed as an unbound rejection handler', async () => {
+    const log = Sinon.stub(console, 'error');
+    const runner = new TestFunctionRunner();
+    const error = new Error('page close failed');
+
+    await Promise.reject(error).catch(runner.log);
+
+    expect(log.calledOnceWithExactly(`_browserless_function_client_: ${error}`))
+      .to.be.true;
+  });
+});

--- a/src/shared/utils/function/client.ts
+++ b/src/shared/utils/function/client.ts
@@ -9,6 +9,7 @@ type codeHandler = (params: {
 
 // puppeteer-core >= 25.6 requires an explicit Logger on these internals.
 const logger = () => undefined;
+const pageCloseTimeout = 2_000;
 
 export class FunctionRunner {
   protected browser?: Browser;
@@ -17,16 +18,90 @@ export class FunctionRunner {
   public log = (err: unknown) =>
     console.error(`_browserless_function_client_: ${err}`);
 
-  protected async runCode(
+  protected async closePage(): Promise<void> {
+    const page = this.page;
+    this.page = undefined;
+    if (!page) return;
+
+    let timeout!: ReturnType<typeof setTimeout>;
+    await Promise.race([
+      Promise.resolve()
+        .then(() => page.close())
+        .catch(this.log),
+      new Promise<void>((resolve) => {
+        timeout = setTimeout(resolve, pageCloseTimeout);
+      }),
+    ]).finally(() => clearTimeout(timeout));
+  }
+
+  protected async runWithBrowser(
     code: codeHandler,
     context: unknown,
-  ): Promise<unknown> {
+    options: {
+      downloadPath?: string;
+      protocolTimeout?: number;
+    },
+  ) {
     try {
-      return await code({ context, page: this.page as Page });
+      this.page = await this.browser!.newPage();
+
+      if (options.downloadPath) {
+        console.debug(
+          `_browserless_function_client_: Setting downloads for page to "${options.downloadPath}"`,
+        );
+        // @ts-ignore
+        const client = this.page._client.call(this.page);
+        await client.send('Page.setDownloadBehavior', {
+          behavior: 'allow',
+          downloadPath: options.downloadPath,
+        });
+      }
+
+      let response: unknown;
+      try {
+        response = await code({ context, page: this.page });
+      } catch (error) {
+        console.error(`Error running code: ${error}`);
+        throw error;
+      }
+
+      console.debug(
+        `_browserless_function_client_: Code is finished executing, closing page.`,
+      );
+      await this.closePage();
+
+      if (response instanceof Uint8Array) {
+        return {
+          contentType: 'uint8array',
+          payload: Array.from(response),
+        };
+      }
+
+      if (typeof response === 'string') {
+        return {
+          contentType: response.startsWith('<') ? 'text/html' : 'text/plain',
+          payload: response,
+        };
+      }
+
+      if (typeof response === 'object') {
+        return {
+          contentType: 'application/json',
+          payload: JSON.stringify(response, null, '  '),
+        };
+      }
+
+      return {
+        contentType: 'text/plain',
+        payload: response,
+      };
     } catch (error) {
-      console.error(`Error running code: ${error}`);
-      await this.page?.close().catch(this.log);
-      this.browser?.disconnect();
+      await this.closePage();
+      try {
+        this.browser?.disconnect();
+      } catch (disconnectError) {
+        this.log(disconnectError);
+      }
       throw error;
     }
   }
@@ -61,51 +136,7 @@ export class FunctionRunner {
       logger,
     )) as unknown as Browser;
     this.browser.once('disconnected', () => this.stop());
-    this.page = await this.browser.newPage();
-
-    if (options.downloadPath) {
-      console.debug(
-        `_browserless_function_client_: Setting downloads for page to "${options.downloadPath}"`,
-      );
-      // @ts-ignore
-      const client = this.page._client.call(this.page);
-      await client.send('Page.setDownloadBehavior', {
-        behavior: 'allow',
-        downloadPath: options.downloadPath,
-      });
-    }
-
-    const response = await this.runCode(code, context);
-    console.debug(
-      `_browserless_function_client_: Code is finished executing, closing page.`,
-    );
-    this.page.close().catch(this.log);
-
-    if (response instanceof Uint8Array) {
-      return {
-        contentType: 'uint8array',
-        payload: Array.from(response),
-      };
-    }
-
-    if (typeof response === 'string') {
-      return {
-        contentType: response.startsWith('<') ? 'text/html' : 'text/plain',
-        payload: response,
-      };
-    }
-
-    if (typeof response === 'object') {
-      return {
-        contentType: 'application/json',
-        payload: JSON.stringify(response, null, '  '),
-      };
-    }
-
-    return {
-      contentType: 'text/plain',
-      payload: response,
-    };
+    return this.runWithBrowser(code, context, options);
   }
 
   public stop() {

--- a/src/shared/utils/function/client.ts
+++ b/src/shared/utils/function/client.ts
@@ -14,8 +14,19 @@ export class FunctionRunner {
   protected browser?: Browser;
   protected page?: Page;
 
-  public log() {
-    return console.log.bind(console);
+  public log = (err: unknown) =>
+    console.error(`_browserless_function_client_: ${err}`);
+
+  protected async runCode(
+    code: codeHandler,
+    context: unknown,
+  ): Promise<unknown> {
+    return code({ context, page: this.page as Page }).catch(async (error) => {
+      console.error(`Error running code: ${error}`);
+      await this.page?.close().catch(this.log);
+      this.browser?.disconnect();
+      throw error;
+    });
   }
 
   public async start(data: {
@@ -62,11 +73,7 @@ export class FunctionRunner {
       });
     }
 
-    const response = await code({ context, page: this.page }).catch((e) => {
-      console.error(`Error running code: ${e}`);
-      this.browser?.disconnect();
-      throw e;
-    });
+    const response = await this.runCode(code, context);
     console.debug(
       `_browserless_function_client_: Code is finished executing, closing page.`,
     );
@@ -106,9 +113,11 @@ export class FunctionRunner {
 
 // Set this as an immutable property on window so our handler's
 // can call it downstream
-Object.defineProperty(window, 'BrowserlessFunctionRunner', {
-  configurable: false,
-  enumerable: false,
-  value: FunctionRunner,
-  writable: false,
-});
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'BrowserlessFunctionRunner', {
+    configurable: false,
+    enumerable: false,
+    value: FunctionRunner,
+    writable: false,
+  });
+}

--- a/src/shared/utils/function/client.ts
+++ b/src/shared/utils/function/client.ts
@@ -21,12 +21,14 @@ export class FunctionRunner {
     code: codeHandler,
     context: unknown,
   ): Promise<unknown> {
-    return code({ context, page: this.page as Page }).catch(async (error) => {
+    try {
+      return await code({ context, page: this.page as Page });
+    } catch (error) {
       console.error(`Error running code: ${error}`);
       await this.page?.close().catch(this.log);
       this.browser?.disconnect();
       throw error;
-    });
+    }
   }
 
   public async start(data: {


### PR DESCRIPTION
## What changed

Function runs now close their page before disconnecting when user code throws or rejects. Cleanup failures are logged without replacing the original user error, and the runner module remains importable in Node for focused tests.

## Why

A failed function run could leave its page alive until the surrounding browser was eventually released. Closing the page while its CDP transport is still connected releases those resources immediately.

## Testing

- `npm run build:tests`
- `npx mocha --no-package build/shared/utils/function/client.spec.js` — 4 passing
- Existing Chromium, Chrome, and Edge function route regressions plus context validation — 38 passing, with 7 pre-existing schema-fixture cases pending

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during browser-based function execution.
  * Ensured pages and browser connections are cleaned up when execution fails.
  * Added safeguards for synchronous and asynchronous errors, including failures while closing pages.
  * Prevented browser-only setup from running in unsupported environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->