### PR TITLE
fix: remediate CodeQL alerts

### DIFF
--- a/src/sdk-utils.spec.ts
+++ b/src/sdk-utils.spec.ts
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import { buildTypeScript } from '@browserless.io/browserless';
+
+describe('SDK utils', () => {
+  let workspaceDir: string;
+  let projectDir: string;
+
+  beforeEach(async () => {
+    workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'browserless-sdk-'));
+    const absoluteProjectDir = path.join(workspaceDir, 'packages', 'sdk');
+    await fs.mkdir(absoluteProjectDir, { recursive: true });
+    projectDir = path.relative(process.cwd(), absoluteProjectDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(workspaceDir, { force: true, recursive: true });
+  });
+
+  it('resolves TypeScript from a relative project and passes arguments literally', async () => {
+    const tscDir = path.join(workspaceDir, 'node_modules', 'typescript', 'bin');
+    const argsFile = path.join(workspaceDir, 'args.json');
+    const marker = path.join(workspaceDir, 'injected');
+    const buildDir = `build; touch ${marker}; #`;
+
+    await fs.mkdir(tscDir, { recursive: true });
+    await fs.writeFile(
+      path.join(tscDir, 'tsc'),
+      `require('fs').writeFileSync(${JSON.stringify(argsFile)}, JSON.stringify(process.argv.slice(2)));\n`,
+    );
+
+    await buildTypeScript(buildDir, projectDir);
+
+    const markerExists = await fs.stat(marker).then(
+      () => true,
+      () => false,
+    );
+    expect(markerExists).to.equal(false);
+    expect(JSON.parse(await fs.readFile(argsFile, 'utf8'))).to.deep.equal([
+      '--outDir',
+      buildDir,
+    ]);
+  });
+});

--- a/src/sdk-utils.ts
+++ b/src/sdk-utils.ts
@@ -1,10 +1,11 @@
 import { createInterface } from 'readline';
+import { createRequire } from 'module';
 import debug from 'debug';
 import fs from 'fs/promises';
 import path from 'path';
 import { promisify } from 'util';
 
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 
 // Ignore node_modules, dist, .next, .cache, coverage for route loading
 // This is to prevent the SDK from loading routes that aren't actual routes
@@ -12,9 +13,14 @@ import { exec } from 'child_process';
 const ignore = ['node_modules', 'dist', '.next', '.cache', 'coverage'];
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
-const waitForCommand = async (cmd: string, workingDirectory: string) =>
-  execAsync(cmd, { cwd: workingDirectory })
+const waitForResult = async (
+  command: string,
+  workingDirectory: string,
+  execution: Promise<{ stderr: string }>,
+): Promise<void> => {
+  return execution
     .then(({ stderr }) => {
       if (stderr) {
         console.warn(
@@ -25,11 +31,22 @@ const waitForCommand = async (cmd: string, workingDirectory: string) =>
     })
     .catch((e) => {
       console.error(
-        `Error running command: "${cmd}" at directory: "${workingDirectory}"`,
+        `Error running command: "${command}" at directory: "${workingDirectory}"`,
         e,
       );
       process.exit(1);
     });
+};
+
+const waitForCommand = (
+  command: string,
+  workingDirectory: string,
+): Promise<void> =>
+  waitForResult(
+    command,
+    workingDirectory,
+    execAsync(command, { cwd: workingDirectory }),
+  );
 
 export const getArgSwitches = () => {
   return process.argv.reduce(
@@ -137,4 +154,16 @@ export const buildDockerImage = async (
 export const buildTypeScript = async (
   buildDir: string,
   projectDir: string,
-): Promise<void> => waitForCommand(`npx tsc --outDir ${buildDir}`, projectDir);
+): Promise<void> => {
+  const workingDirectory = path.resolve(projectDir);
+  const tscPath = createRequire(
+    path.join(workingDirectory, 'package.json'),
+  ).resolve('typescript/bin/tsc');
+  return waitForResult(
+    process.execPath,
+    workingDirectory,
+    execFileAsync(process.execPath, [tscPath, '--outDir', buildDir], {
+      cwd: workingDirectory,
+    }),
+  );
+};

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -4,6 +4,7 @@ import { ServerResponse } from 'http';
 import { Socket } from 'net';
 import os from 'os';
 import path from 'path';
+import { PassThrough } from 'stream';
 import {
   Config,
   contentTypes,
@@ -114,6 +115,23 @@ describe('Utils', () => {
       expect(getBody()).to.equal('Not found\n');
     });
 
+    it('uses plain text for non-JSON errors', () => {
+      const { res, getHead, getBody } = createMockResponse();
+      const message = '<script>globalThis.exploited = true</script>';
+      writeResponse(res, 400, message, contentTypes.html);
+
+      expect(getHead().headers?.['Content-Type']).to.equal(
+        'text/plain; charset=UTF-8',
+      );
+      expect(getBody()).to.equal(`${message}\n`);
+
+      const socket = new PassThrough();
+      writeResponse(socket, 400, message, contentTypes.html);
+      expect(socket.read()?.toString()).to.include(
+        'Content-Type: text/plain; charset=UTF-8',
+      );
+    });
+
     it('returns JSON error object when contentType is json', () => {
       const { res, getHead, getBody } = createMockResponse();
       writeResponse(res, 400, 'Missing parameter', contentTypes.json);
@@ -148,6 +166,9 @@ describe('Utils', () => {
       );
 
       expect(getHead().code).to.equal(408);
+      expect(getHead().headers?.['Content-Type']).to.equal(
+        'application/json; charset=UTF-8',
+      );
       const parsed = JSON.parse(getBody().trim());
       expect(parsed).to.deep.equal({ error: 'Validation failed' });
     });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -181,9 +181,15 @@ export const writeResponse = (
   const isJSON = contentType.includes(contentTypes.json);
   const isError = httpCode >= 400;
   const httpMessage = codes[httpCode];
-  const CTTHeader = contentType.toLowerCase().includes('charset=')
-    ? contentType
-    : `${contentType}; charset=${encodings.utf8}`;
+  let responseContentType = contentType;
+  if (isError) {
+    responseContentType = isJSON ? contentTypes.json : contentTypes.text;
+  }
+  const contentTypeHeader = responseContentType
+    .toLowerCase()
+    .includes('charset=')
+    ? responseContentType
+    : `${responseContentType}; charset=${encodings.utf8}`;
   const body =
     isJSON && isError
       ? JSON.stringify({
@@ -194,7 +200,9 @@ export const writeResponse = (
   if (isHTTP(writeable)) {
     const response = writeable;
     if (!response.headersSent) {
-      response.writeHead(httpMessage.code, { 'Content-Type': CTTHeader });
+      response.writeHead(httpMessage.code, {
+        'Content-Type': contentTypeHeader,
+      });
       response.end(body + '\n');
     }
     return;
@@ -202,7 +210,7 @@ export const writeResponse = (
 
   const httpResponse = [
     httpMessage.message,
-    `Content-Type: ${CTTHeader}`,
+    `Content-Type: ${contentTypeHeader}`,
     'Content-Encoding: UTF-8',
     'Accept-Ranges: bytes',
     'Connection: keep-alive',


### PR DESCRIPTION
## Summary

- compile SDK TypeScript through Node with an argument array instead of constructing a shell command
- normalize non-JSON error responses to `text/plain` while preserving successful response types
- add focused regressions for shell metacharacters, relative/hoisted SDK installs, and active-content error bodies

## Security analysis

The shell-command finding was valid at the exported library boundary: `buildDir` was concatenated into a command interpreted by a shell. The replacement resolves the SDK project's TypeScript entrypoint and executes it with `execFile`, preserving each value as a single argument on all supported platforms.

The reported exception-XSS dataflow is infeasible: it assumes a dependency exception can become one of Browserless's local typed HTTP errors. Other dependency exceptions receive a fixed generic 500 body. As defense in depth, this change also prevents all non-JSON error text from being labeled as active HTML. CodeQL still reports the raw `Duplex.write` sink because the query does not model the emitted `Content-Type`; alert #54 should therefore be dismissed as a false positive after review rather than broadly suppressed in source.

## Verification

- `npm run build:ts`
- `npx mocha --no-package build/sdk-utils.spec.js build/utils.spec.js` (28 passing)
- scoped ESLint and Prettier checks
- CodeQL 2.26.4 default JavaScript code-scanning suite (shell finding removed; only the documented exception-XSS false positive remains)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript build execution so output paths are handled safely without unintended shell interpretation.
  * Standardized response content-type handling across HTTP and stream responses.
  * Ensured error responses remain JSON or plain text according to the requested content type, preventing executable HTML from being returned as an error body.

* **Tests**
  * Added coverage for secure build execution, response streaming, content-type normalization, and non-JSON error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->