### PR TITLE
fix: serve the images the API docs page references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ static/debugger/*
 static/docs/swagger.json
 static/docs/swagger.min.json
 
+# Docs images copied from ./assets at build time
+static/docs/assets/
+
 # Coverage
 coverage
 

--- a/scripts/build-open-api.js
+++ b/scripts/build-open-api.js
@@ -36,6 +36,8 @@ const copyReferencedAssets = async (markdown) => {
     return;
   }
 
+  const assetsDir = join(process.cwd(), 'assets');
+
   await fs.mkdir(docsAssetsDir, { recursive: true });
 
   // A reference with no readable file behind it costs the docs page an image,
@@ -43,10 +45,7 @@ const copyReferencedAssets = async (markdown) => {
   await Promise.all(
     referenced.map((file) =>
       fs
-        .copyFile(
-          join(process.cwd(), 'assets', file),
-          join(docsAssetsDir, file),
-        )
+        .copyFile(join(assetsDir, file), join(docsAssetsDir, file))
         .catch(() => {}),
     ),
   );

--- a/scripts/build-open-api.js
+++ b/scripts/build-open-api.js
@@ -85,7 +85,7 @@ const buildOpenAPI = async (
       version: JSON.parse(packageJSON.toString()).version,
       'x-logo': {
         altText: 'browserless logo',
-        url: './docs/browserless-logo-inline.svg',
+        url: './browserless-logo-inline.svg',
       },
     },
     openapi: '3.0.0',

--- a/scripts/build-open-api.js
+++ b/scripts/build-open-api.js
@@ -19,6 +19,38 @@ const swaggerJSONMinimal = join(
   'swagger.min.json',
 );
 const packageJSONPath = join(__dirname, '..', 'package.json');
+const docsAssetsDir = join(__dirname, '..', 'static', 'docs', 'assets');
+const assetReferences = /\.\/assets\/([\w.-]+)/g;
+
+// Redoc resolves the embedded README against the docs page at `/docs/`, so
+// every `./assets/...` reference it carries has to be served from
+// `/docs/assets/`. Only `static` is served, and `assets` sits outside it.
+// Sources follow the README's own root rather than this package's, so an SDK
+// consumer's assets are used with an SDK consumer's README.
+const copyReferencedAssets = async (markdown) => {
+  const referenced = [
+    ...new Set([...markdown.matchAll(assetReferences)].map(([, file]) => file)),
+  ];
+
+  if (!referenced.length) {
+    return;
+  }
+
+  await fs.mkdir(docsAssetsDir, { recursive: true });
+
+  // A reference with no readable file behind it costs the docs page an image,
+  // which is never worth failing a build over.
+  await Promise.all(
+    referenced.map((file) =>
+      fs
+        .copyFile(
+          join(process.cwd(), 'assets', file),
+          join(docsAssetsDir, file),
+        )
+        .catch(() => {}),
+    ),
+  );
+};
 
 const readFileOrNull = async (path) => {
   if (!path) {
@@ -75,6 +107,8 @@ const buildOpenAPI = async (
   const changelog = marked.parse(
     (await fs.readFile('CHANGELOG.md').catch(() => '')).toString(),
   );
+
+  await copyReferencedAssets(readme);
 
   const [httpRoutes, wsRoutes] = await getRouteFiles(new Config());
   const swaggerJSON = {

--- a/src/routes/management/tests/management.spec.ts
+++ b/src/routes/management/tests/management.spec.ts
@@ -198,6 +198,36 @@ describe('Management APIs', function () {
       });
     });
 
+    it('serves the images the docs page resolves against /docs/', async () => {
+      await start();
+
+      const spec = await fetch(
+        'http://localhost:3000/docs/swagger.json?token=6R0W53R135510',
+      ).then((res) => res.json() as Promise<any>);
+
+      const references = [
+        spec.info['x-logo'].url,
+        ...[
+          ...spec.info.description.matchAll(/(?:src|srcset)="(\.\/[^"]+)"/g),
+        ].map(([, url]: string[]) => url),
+      ];
+
+      expect(references.length).to.be.greaterThan(1);
+
+      await Promise.all(
+        references.map(async (reference: string) => {
+          const url = new URL(reference, 'http://localhost:3000/docs/');
+          url.searchParams.set('token', '6R0W53R135510');
+
+          const res = await fetch(url);
+          expect(res.status, reference).to.equal(200);
+          expect(res.headers.get('content-type'), reference).to.match(
+            /^image\//,
+          );
+        }),
+      );
+    });
+
     it('returns 404 if debugger is disabled', async () => {
       process.env.ENABLE_DEBUGGER = 'false';
       const config = new Config();

--- a/src/routes/management/tests/management.spec.ts
+++ b/src/routes/management/tests/management.spec.ts
@@ -205,17 +205,17 @@ describe('Management APIs', function () {
         'http://localhost:3000/docs/swagger.json?token=6R0W53R135510',
       ).then((res) => res.json() as Promise<any>);
 
-      const references = [
+      const references: string[] = [
         spec.info['x-logo'].url,
         ...[
           ...spec.info.description.matchAll(/(?:src|srcset)="(\.\/[^"]+)"/g),
-        ].map(([, url]: string[]) => url),
+        ].map(([, url]) => url),
       ];
 
       expect(references.length).to.be.greaterThan(1);
 
       await Promise.all(
-        references.map(async (reference: string) => {
+        references.map(async (reference) => {
           const url = new URL(reference, 'http://localhost:3000/docs/');
           url.searchParams.set('token', '6R0W53R135510');
 


### PR DESCRIPTION
## Description

Every image on the API docs page at `/docs/` was 404ing. Two separate causes, both reaching the page through the generated OpenAPI spec.

### What people will notice

The logo is back in the docs header, and the README banner at the top of the description renders instead of showing broken images. Nothing else changes: no route, schema, response, or served path is touched.

### The problems fixed

1. **Redoc's own logo.** `info['x-logo'].url` was `./docs/browserless-logo-inline.svg`. Redoc resolves that against the page URL, which was `/docs` when the value was written, so it landed on `/docs/browserless-logo-inline.svg`. #5182 made the static route redirect a directory request to its trailing-slash form, so the page is now always `/docs/` and the same value resolves to `/docs/docs/browserless-logo-inline.svg`. That PR switched the Redoc `spec-url` in `static/docs/index.html` to an absolute path for the same reason, but missed this value, which lives in the generated spec rather than in the HTML. It is now `./browserless-logo-inline.svg`, which resolves correctly at both `/docs/` and `/docs/index.html`.

2. **The README banner.** The spec embeds `README.md` as its description, so the README's `./assets/logo.svg` and `./assets/logo-white.svg` resolve to `/docs/assets/`. Only `static` is served and `assets` sits outside it, so nothing answered there. The build step now copies the files the README references into `static/docs/assets`, gitignored alongside the generated spec.

### Why copies rather than a symlink

`static/assets` is already a tracked symlink into `assets`, so mirroring it under `static/docs` looked cleaner. `npm pack` drops symlinks, though, and the published tarball carries no `static/assets` at all. A symlink would have fixed this repo's own images while leaving every npm and SDK consumer still 404ing.

Sources resolve from the working directory, the same root the README is read from, so an SDK consumer's README pairs with that consumer's own assets. The destination stays inside the package, because that is the directory served for consumers and where the generated spec is already written.

### Testing

- A new test in `src/routes/management/tests/management.spec.ts` walks every relative image reference the served spec carries, the logo and the README banner alike, and asserts each returns 200 with an image content type. Confirmed it fails with a 404 when the copied images are removed.
- Ran the existing docs tests, `tsc --noEmit`, and `prettier --check`.
- Checked against a running server: `/docs/assets/logo.svg`, `/docs/assets/logo-white.svg` and `/docs/browserless-logo-inline.svg` each return 200 with `image/svg+xml`.
- Regenerating the spec on this branch and on the base branch produces output differing only in the logo value.

### Known limitation

The embedded README also links to `./LEARN_MORE.md`, which resolves to `/docs/LEARN_MORE.md` and still 404s. Fixing that means pointing the link outside the served directory rather than copying a file, so it is left alone here.
