### PR TITLE
fix: update Playwright to 1.63 with versioned compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,11 +20,11 @@
         "http-proxy": "^1.18.1",
         "lighthouse": "^13.4.1",
         "micromatch": "^4.0.8",
-        "playwright-1.58": "npm:playwright-core@1.58.2",
         "playwright-1.59": "npm:playwright-core@1.59.1",
         "playwright-1.60": "npm:playwright-core@1.60.0",
         "playwright-1.61": "npm:playwright-core@1.61.1",
-        "playwright-core": "1.62.1",
+        "playwright-1.62": "npm:playwright-core@1.62.1",
+        "playwright-core": "1.63.0",
         "puppeteer-core": "25.10.0",
         "queue": "^7.0.0",
         "systeminformation": "^5.33.8",
@@ -52,7 +52,7 @@
         "env-cmd": "^11.0.0",
         "esbuild": "^0.28.2",
         "esbuild-plugins-node-modules-polyfill": "^1.8.3",
-        "eslint": "^10.9.1",
+        "eslint": "^10.10.0",
         "gunzip-maybe": "^1.4.2",
         "husky": "^9.1.7",
         "lint-staged": "^17.4.1",
@@ -129,6 +129,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@cacheable/memory": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.2.0.tgz",
+      "integrity": "sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.5.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+      "integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
       }
     },
     "node_modules/@commander-js/extra-typings": {
@@ -684,9 +708,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
-      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.3.tgz",
+      "integrity": "sha512-IkO+/KEUvwbVpiURZg+P7zF74z5Jxe0UgJxVni+RtoHQ6IZieXaO02kmadomap/q+l6bc/jdPGGqTjhuZnuz1Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -857,6 +881,30 @@
       "integrity": "sha512-3sRl+pkyFY/kLmHl0cgHiFp2xEqErA8N3ECjMs7serSUBmoJ70lBa0PG5t0IM6WJgdZNyyI0R8YFfi5wM8+mzg==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2394,6 +2442,20 @@
         "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
+    "node_modules/cacheable": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
+      "integrity": "sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.2.0",
+        "@cacheable/utils": "^2.5.0",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.10.1"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2862,9 +2924,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz",
-      "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.10.0.tgz",
+      "integrity": "sha512-NPXn6r5zl4uET1DAVPaOwzX3rut4c0wcmw3dWJAfOsTM5+TogXo0DDjz8pwm/hL8cyVNpHqeK4JpN0NjnyFFNw==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -2876,7 +2938,7 @@
         "@eslint/config-array": "^0.23.5",
         "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.2",
+        "@eslint/plugin-kit": "^0.7.3",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -2891,7 +2953,7 @@
         "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^8.0.0",
+        "file-entry-cache": "11.1.5 || >11.1.6 <12",
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
         "ignore": "^5.2.0",
@@ -3176,16 +3238,13 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.5.tgz",
+      "integrity": "sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "flat-cache": "^6.1.23"
       }
     },
     "node_modules/file-type": {
@@ -3236,23 +3295,21 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "version": "6.1.23",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.23.tgz",
+      "integrity": "sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flatted": "^3.2.9",
-        "keyv": "^4.5.4"
-      },
-      "engines": {
-        "node": ">=16"
+        "cacheable": "^2.5.0",
+        "flatted": "^3.4.2",
+        "hookified": "^1.15.0"
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -3444,6 +3501,26 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -3816,13 +3893,6 @@
         "js-yaml": "bin/js-yaml.mjs"
       }
     },
-    "node_modules/json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -3837,13 +3907,13 @@
       "license": "MIT"
     },
     "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "json-buffer": "3.0.1"
+        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/kind-of": {
@@ -4527,19 +4597,6 @@
         "pathe": "^2.0.3"
       }
     },
-    "node_modules/playwright-1.58": {
-      "name": "playwright-core",
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/playwright-1.59": {
       "name": "playwright-core",
       "version": "1.59.1",
@@ -4579,10 +4636,23 @@
         "node": ">=18"
       }
     },
-    "node_modules/playwright-core": {
+    "node_modules/playwright-1.62": {
+      "name": "playwright-core",
       "version": "1.62.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
       "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -4701,6 +4771,26 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1666840.tgz",
       "integrity": "sha512-gCcO42XCHKEs7Ag0S7aGYsnJ7hlgrO3qderYqeiY0Eqk+0GFfuvT13IA0hHreJTa2KCdDVyGMeOhdMNmrrTjVg==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/qified": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+      "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/quansync": {
       "version": "0.2.11",

--- a/package.json
+++ b/package.json
@@ -68,11 +68,11 @@
     "http-proxy": "^1.18.1",
     "lighthouse": "^13.4.1",
     "micromatch": "^4.0.8",
-    "playwright-1.58": "npm:playwright-core@1.58.2",
     "playwright-1.59": "npm:playwright-core@1.59.1",
     "playwright-1.60": "npm:playwright-core@1.60.0",
     "playwright-1.61": "npm:playwright-core@1.61.1",
-    "playwright-core": "1.62.1",
+    "playwright-1.62": "npm:playwright-core@1.62.1",
+    "playwright-core": "1.63.0",
     "puppeteer-core": "25.10.0",
     "queue": "^7.0.0",
     "systeminformation": "^5.33.8",
@@ -97,7 +97,7 @@
     "env-cmd": "^11.0.0",
     "esbuild": "^0.28.2",
     "esbuild-plugins-node-modules-polyfill": "^1.8.3",
-    "eslint": "^10.9.1",
+    "eslint": "^10.10.0",
     "gunzip-maybe": "^1.4.2",
     "husky": "^9.1.7",
     "lint-staged": "^17.4.1",
@@ -115,11 +115,11 @@
   },
   "playwrightVersions": {
     "default": "playwright-core",
-    "1.62": "playwright-core",
+    "1.63": "playwright-core",
+    "1.62": "playwright-1.62",
     "1.61": "playwright-1.61",
     "1.60": "playwright-1.60",
-    "1.59": "playwright-1.59",
-    "1.58": "playwright-1.58"
+    "1.59": "playwright-1.59"
   },
   "engines": {
     "node": ">=24",

--- a/src/browsers/browsers.cdp.ts
+++ b/src/browsers/browsers.cdp.ts
@@ -386,6 +386,9 @@ export class ChromiumCDP extends EventEmitter {
       args: [
         `--remote-debugging-port=${this.port}`,
         `--no-sandbox`,
+        // Chrome 152's first-run UI prevents remote debugging from starting.
+        // Keep launches non-interactive even with ignoreDefaultArgs: true.
+        `--no-first-run`,
         // Playwright 1.57+ uses Chrome For Test, which has stricter security than Chromium.
         // This is needed to allow WebSocket connections to localhost.
         `--disable-features=LocalNetworkAccessChecks`,

--- a/src/browsers/browsers.playwright.spec.ts
+++ b/src/browsers/browsers.playwright.spec.ts
@@ -887,7 +887,7 @@ describe('BasePlaywright --disable-features merging (issue #5450)', () => {
   describe('Config.getChromiumDisabledFeatures (overridable seam)', () => {
     it('returns the default list for current/unknown versions', () => {
       const cfg = new Config();
-      for (const v of [undefined, 'default', '1.62', '1.99']) {
+      for (const v of [undefined, 'default', '1.63', '1.99']) {
         expect(cfg.getChromiumDisabledFeatures(v)).to.deep.equal(
           defaultFeatures,
         );
@@ -895,10 +895,17 @@ describe('BasePlaywright --disable-features merging (issue #5450)', () => {
       expect(defaultFeatures).to.include(
         'BlockOriginHeaderModificationOnRedirect',
       );
-      expect(defaultFeatures).to.include(
+      expect(defaultFeatures).to.not.include(
         'BoundaryEventDispatchTracksNodeRemoval',
       );
       expect(defaultFeatures).to.not.include('RenderDocument');
+    });
+
+    it('preserves the removed boundary-event feature for 1.62', () => {
+      const f162 = new Config().getChromiumDisabledFeatures('1.62');
+      expect(f162).to.include('BoundaryEventDispatchTracksNodeRemoval');
+      expect(f162).to.include('BlockOriginHeaderModificationOnRedirect');
+      expect(f162).to.not.include('RenderDocument');
     });
 
     it('returns a version-specific list where it differs (1.61)', () => {
@@ -1026,11 +1033,11 @@ describe('BasePlaywright --disable-features merging (issue #5450)', () => {
     // real dependency installed in node_modules (see package.json
     // `playwrightVersions`). The mirror must match each one.
     const SUPPORTED_PW_VERSIONS: Readonly<Record<string, string>> = {
-      '1.58': 'playwright-1.58',
       '1.59': 'playwright-1.59',
       '1.60': 'playwright-1.60',
       '1.61': 'playwright-1.61',
-      '1.62': 'playwright-core',
+      '1.62': 'playwright-1.62',
+      '1.63': 'playwright-core',
     };
 
     type ChromiumLauncher = {
@@ -1127,7 +1134,7 @@ describe('BasePlaywright --disable-features merging (issue #5450)', () => {
       "browserless's merged --disable-features is the one Chromium keeps",
       async () => {
         const argv = await captureLaunchArgv(
-          await chromiumFor(SUPPORTED_PW_VERSIONS['1.62']),
+          await chromiumFor(SUPPORTED_PW_VERSIONS['1.63']),
           launchArgs(ChromiumPlaywright, []),
         );
         const disableFlags = disableFeaturesFlags(argv);

--- a/src/config.ts
+++ b/src/config.ts
@@ -116,7 +116,7 @@ const getDebug = () => {
 
 /**
  * Chromium features Playwright disables by default, mirrored per supported
- * Playwright version (verified against playwright-core 1.58–1.62).
+ * Playwright version (verified against playwright-core 1.59–1.63).
  *
  * `--disable-features` is a single-valued Chromium switch: when it appears more
  * than once on the command line Chrome keeps ONLY the last occurrence — the
@@ -126,14 +126,13 @@ const getDebug = () => {
  * version itself disables or those features are silently re-enabled (e.g.
  * RenderDocument). See https://github.com/browserless/browserless/issues/5450
  *
- * The default is what the pinned playwright-core emits (1.62); versions whose
+ * The default is what the pinned playwright-core emits (1.63); versions whose
  * list differs are overridden below. These lists must stay 1:1 with the
  * installed Playwright versions — see the drift test in
  * browsers.playwright.spec.ts.
  */
 const defaultChromiumDisabledFeatures: readonly string[] = [
   'AvoidUnnecessaryBeforeUnloadCheckSync',
-  'BoundaryEventDispatchTracksNodeRemoval',
   'DestroyProfileOnBrowserClose',
   'DialMediaRouteProvider',
   'GlobalMediaControls',
@@ -172,9 +171,9 @@ const playwright160And161DisabledFeatures: readonly string[] = [
   'msEdgeUpdateLaunchServicesPreferredVersion',
 ];
 
-// 1.58 and 1.59 match 1.60/1.61 except the ms*/Edge features, which Playwright
+// 1.59 matches 1.60/1.61 except the ms*/Edge features, which Playwright
 // began disabling in 1.60.
-const playwright158And159DisabledFeatures: readonly string[] = [
+const playwright159DisabledFeatures: readonly string[] = [
   'AvoidUnnecessaryBeforeUnloadCheckSync',
   'BoundaryEventDispatchTracksNodeRemoval',
   'DestroyProfileOnBrowserClose',
@@ -194,10 +193,14 @@ const playwright158And159DisabledFeatures: readonly string[] = [
 const chromiumDisabledFeaturesByPwVersion: Readonly<
   Record<string, readonly string[]>
 > = {
-  '1.58': playwright158And159DisabledFeatures,
-  '1.59': playwright158And159DisabledFeatures,
+  '1.59': playwright159DisabledFeatures,
   '1.60': playwright160And161DisabledFeatures,
   '1.61': playwright160And161DisabledFeatures,
+  // Playwright stopped disabling this feature in 1.63.
+  '1.62': [
+    ...defaultChromiumDisabledFeatures,
+    'BoundaryEventDispatchTracksNodeRemoval',
+  ],
 };
 
 /**


### PR DESCRIPTION
## Summary

- Upgrade Playwright from 1.62.1 to 1.63.0 and ESLint from 10.9.1 to 10.10.0, replacing #5572.
- Keep five supported Playwright minor versions (1.59–1.63): add the `playwright-1.62` alias, retire 1.58, and update the version map used for routing and `/meta`.
- Match Chromium's disabled-feature defaults for every supported version, preserving 1.62's boundary-event feature while removing it from the 1.63 default.
- Preserve `--no-first-run` in CDP launches so Chrome 152 starts remote debugging even with `ignoreDefaultArgs: true`.

Follows the version-window maintenance in #5370, #5446, and #5520. The existing historical-browser installer remains unchanged because 1.59 still needs its compatibility workaround.

## Verification

- Full build and test-artifact build.
- ESLint and Prettier checks.
- 68 focused Playwright tests, including live launch-argument comparison for all five supported versions.
- Existing Chromium ignored-defaults regression: fails with the upgraded browser before the launcher fix, passes afterward; unchanged main also passes.
- Installed current and historical Chromium, Firefox, and WebKit binaries using the repository's installer.
- Complete local suite: 711 passing, 3 pending, one kill-session teardown timeout. The same Edge teardown timeout reproduces on unchanged main when running the Chrome/Chromium/Edge kill-session files together; individual Chromium kill-session tests pass. No unrelated teardown change is included.

The pull request's browser-image CI matrix provides the final per-image verification.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Chrome launches now avoid first-run prompts, providing a smoother and more reliable startup experience.

- **Compatibility**
  - Updated browser automation support for newer Playwright versions.
  - Refined Chromium feature handling to maintain consistent behavior across supported Playwright versions.

- **Tests**
  - Expanded coverage for browser launching, version compatibility, and Chromium feature configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->