### PR TITLE
fix: block URLs with Network.setBlockedURLs, not Fetch (PLT-1596)

### DIFF
--- a/src/browsers/browsers.cdp.spec.ts
+++ b/src/browsers/browsers.cdp.spec.ts
@@ -8,6 +8,7 @@ import {
 import { Server, createServer } from 'http';
 import { AddressInfo } from 'net';
 import { expect } from 'chai';
+import puppeteer from 'puppeteer-core';
 
 import { ChromiumCDP } from './browsers.cdp.js';
 
@@ -71,7 +72,10 @@ describe('ChromiumCDP launch args', function () {
 describe('ChromiumCDP blocked-URL guard', function () {
   let browser: ChromiumCDP | undefined;
   let server: Server | undefined;
+  let proxy: Server | undefined;
   let port = 0;
+  let proxyPort = 0;
+  let proxyChallenges = 0;
   let hits: string[] = [];
 
   // A range set mirroring what a consumer opts into: loopback plus localhost.
@@ -97,15 +101,49 @@ describe('ChromiumCDP blocked-URL guard', function () {
 
   beforeEach(async () => {
     hits = [];
+    proxyChallenges = 0;
     server = createServer((req, res) => {
       hits.push(req.url ?? '');
+      // A 401 endpoint for the page.authenticate() cases; everything else is
+      // an image, which is the shape the blocked sub-resource cases use.
+      if (req.url?.startsWith('/auth')) {
+        if (!req.headers.authorization) {
+          res.writeHead(401, {
+            'content-type': 'text/html',
+            'www-authenticate': 'Basic realm="probe"',
+          });
+          return res.end('<html><body>denied</body></html>');
+        }
+        res.writeHead(200, { 'content-type': 'text/html' });
+        return res.end('<html><body>authed</body></html>');
+      }
       res.writeHead(200, { 'content-type': 'image/svg+xml' });
-      res.end('<svg xmlns="http://www.w3.org/2000/svg"/>');
+      return res.end('<svg xmlns="http://www.w3.org/2000/svg"/>');
     });
     await new Promise<void>((resolve) =>
       server!.listen(0, '127.0.0.1', resolve),
     );
     port = (server!.address() as AddressInfo).port;
+
+    // A proxy that challenges once, so a 407 has to reach the client the same
+    // way a 401 does. Chromium sends absolute-form requests to a proxy, so
+    // nothing here has to resolve the name it is asked for.
+    proxy = createServer((req, res) => {
+      if (!req.headers['proxy-authorization']) {
+        proxyChallenges++;
+        res.writeHead(407, {
+          'content-type': 'text/html',
+          'proxy-authenticate': 'Basic realm="probe"',
+        });
+        return res.end('<html><body>proxy denied</body></html>');
+      }
+      res.writeHead(200, { 'content-type': 'text/html' });
+      return res.end('<html><body>authed</body></html>');
+    });
+    await new Promise<void>((resolve) =>
+      proxy!.listen(0, '127.0.0.1', resolve),
+    );
+    proxyPort = (proxy!.address() as AddressInfo).port;
   });
 
   afterEach(async () => {
@@ -113,6 +151,8 @@ describe('ChromiumCDP blocked-URL guard', function () {
     browser = undefined;
     server?.close();
     server = undefined;
+    proxy?.close();
+    proxy = undefined;
   });
 
   // Positive assertions ("the request did happen", "the session did close")
@@ -130,17 +170,29 @@ describe('ChromiumCDP blocked-URL guard', function () {
     }
   };
 
-  const newGuardedPage = async () => {
+  const launchGuarded = async (args: string[] = []) => {
     browser = new ChromiumCDP({
       blockAds: false,
       config: new GuardedConfig(),
       logger: new Logger('browsers.cdp.spec'),
       userDataDir: null,
     });
-    await browser.launch({ options: { args: [] }, stealth: false });
-    const page = await browser.newPage();
+    await browser.launch({ options: { args }, stealth: false });
+    return browser;
+  };
+
+  // Resolves every hostname to the probe server, so a case can use a name the
+  // blocklist has an opinion about — or a lookalike it must not — and still be
+  // served locally.
+  const resolveEverythingLocally = () => [
+    `--host-resolver-rules=MAP * 127.0.0.1:${port}`,
+  ];
+
+  const newGuardedPage = async (args: string[] = []) => {
+    await launchGuarded(args);
+    const page = await browser!.newPage();
     // 'targetcreated' fires the guard install asynchronously, so newPage() can
-    // resolve before Fetch interception is live.
+    // resolve before the blocklist is live.
     await new Promise((resolve) => setTimeout(resolve, 500));
     return page;
   };
@@ -176,10 +228,11 @@ describe('ChromiumCDP blocked-URL guard', function () {
     expect(await page.evaluate(() => 1 + 1)).to.equal(2);
   });
 
-  // The reason this guard intercepts rather than using
-  // Network.setBlockedURLs: glob blocking has no notion of an exemption, so
-  // blocking loopback would also block the pages browserless serves itself
-  // (e.g. the /function runtime).
+  // `Network.setBlockedURLs` has no notion of an exemption, so the carve-out
+  // has to be baked into the patterns (toBlockedUrlPatterns). Without it the
+  // pages browserless serves itself — the /function runtime and its code —
+  // stop loading, and blocking beats interception to the request, so the
+  // handler that serves them never gets the chance.
   it("still allows the server's own origin through the same host", async () => {
     class SelfHostedConfig extends GuardedConfig {
       public getSelfNavigationHosts(): string[] {
@@ -223,10 +276,13 @@ describe('ChromiumCDP blocked-URL guard', function () {
     });
   }
 
-  // A credentialed navigation keeps its userinfo all the way to the pattern
-  // matcher, so `*://127.*` alone would miss it and leave only the
-  // observational path — which cannot stop a request that has already left.
-  it('blocks a navigation that hides the host behind userinfo', async () => {
+  // Navigations are the one thing `Network.setBlockedURLs` does not apply to
+  // (measured — sub-resources and renderer fetches are blocked, navigations
+  // are not), so this is the observational teardown doing its job, not the
+  // blocklist. The request does leave the browser; the route-level 403 and the
+  // wire-protocol check are what stop the ones they can see, and a teardown
+  // could never have unsent it anyway.
+  it('still terminates a navigation that hides the host behind userinfo', async () => {
     const page = await newGuardedPage();
 
     await page
@@ -234,12 +290,107 @@ describe('ChromiumCDP blocked-URL guard', function () {
       .catch(() => {});
     await waitFor(() => !browser!.isRunning());
 
-    expect(hits, 'credentialed navigation must not reach the destination').to.be
-      .empty;
-    // Both halves, or the test passes on a guard that fails the request and
-    // leaves the session up — which is the sub-resource behaviour, not the
-    // navigation one.
     expect(browser!.isRunning(), 'blocked navigation must end the session').to
       .be.false;
+  });
+
+  // PLT-1596. The guard this replaced enabled `Fetch` on a second CDP session,
+  // which swallowed the auth challenge for every request on the target: the
+  // client was never asked for credentials and Chromium failed the navigation
+  // with ERR_INVALID_AUTH_CREDENTIALS. It broke whether or not anything
+  // matched the blocklist, and it took out ~5% of one customer's sessions.
+  //
+  // The client is a second puppeteer connection, as in production: the server
+  // installs the guard on `targetcreated`, the customer drives a page over
+  // their own connection.
+  describe('with a client calling page.authenticate()', () => {
+    const connectClient = async () => {
+      const browserWSEndpoint = browser!.wsEndpoint();
+      expect(browserWSEndpoint, 'browser should expose an endpoint').to.be.a(
+        'string',
+      );
+      return puppeteer.connect({ browserWSEndpoint: browserWSEndpoint! });
+    };
+
+    // Three sequential pages: the original failure was a race between the
+    // guard landing on the target and authenticate() arming, so one pass
+    // proves less than a handful do.
+    it('answers a site (401) challenge', async () => {
+      // `auth.test` is deliberately not a name the blocklist covers: the
+      // pre-fix guard broke auth even when nothing matched its patterns, and a
+      // blocked host would confuse that with the navigation teardown.
+      await launchGuarded(resolveEverythingLocally());
+      const client = await connectClient();
+
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const page = await client.newPage();
+        // 'targetcreated' installs the guard asynchronously; give it the same
+        // head start the pre-fix guard needed to lose this race.
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        await page.authenticate({ password: 'pass', username: 'user' });
+
+        const response = await page.goto('http://auth.test/auth', {
+          timeout: 10_000,
+        });
+
+        expect(response?.status(), `attempt ${attempt}`).to.equal(200);
+        expect(await page.evaluate(() => document.body.textContent)).to.equal(
+          'authed',
+        );
+        await page.close();
+      }
+
+      await client.disconnect();
+    });
+
+    // The reported case: `/chrome?--proxy-server=…` with no credentials in the
+    // flag, so the 407 has to reach the client's authenticate() too.
+    it('answers a proxy (407) challenge', async () => {
+      await launchGuarded([
+        `--proxy-server=127.0.0.1:${proxyPort}`,
+        // Chromium exempts loopback from proxying unless told otherwise.
+        '--proxy-bypass-list=<-loopback>',
+      ]);
+      const client = await connectClient();
+      const page = await client.newPage();
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      await page.authenticate({ password: 'pass', username: 'user' });
+
+      const response = await page.goto('http://proxied.test/auth', {
+        timeout: 10_000,
+      });
+
+      expect(response?.status()).to.equal(200);
+      expect(
+        proxyChallenges,
+        'the proxy must have issued a challenge',
+      ).to.be.greaterThan(0);
+      await client.disconnect();
+    });
+  });
+
+  // The patterns are the verdict now — nothing pauses to ask the matcher
+  // afterwards — so a pattern that over-matches is a customer's sub-resource
+  // that silently fails. This is the browser end of the anchoring asserted in
+  // network-security.spec.ts: it also pins the assumption that Chromium
+  // matches a pattern as an unanchored substring, which is what
+  // matchesBlockedUrlPattern mirrors.
+  it('leaves lookalike hosts alone', async () => {
+    // Requested for real, rather than asserted against a re-implementation of
+    // Chromium's matcher.
+    const page = await newGuardedPage(resolveEverythingLocally());
+
+    // 0.gravatar.com is the one that matters: an unanchored `0.` pattern
+    // blocks it, and it sits on a great many WordPress sites.
+    await page.setContent(
+      '<img src="http://0.gravatar.test/avatar.svg">' +
+        '<img src="http://localhostings.test/logo.svg">' +
+        '<img src="http://127.example.test/logo.svg">',
+    );
+    const loaded = () => hits.filter((hit) => hit.endsWith('.svg')).length;
+    await waitFor(() => loaded() >= 3);
+
+    expect(loaded(), 'lookalike hosts must load').to.equal(3);
+    expect(browser!.isRunning()).to.be.true;
   });
 });

--- a/src/browsers/browsers.cdp.ts
+++ b/src/browsers/browsers.cdp.ts
@@ -10,10 +10,10 @@ import {
   findBlockedNavigationUrl,
   noop,
   once,
-  toBlockedUrlInterceptPatterns,
+  toBlockedUrlPatterns,
   ublockLitePath,
 } from '@browserless.io/browserless';
-import puppeteer, { Browser, Page, Target } from 'puppeteer-core';
+import puppeteer, { Browser, CDPSession, Page, Target } from 'puppeteer-core';
 import { Duplex } from 'stream';
 import { EventEmitter } from 'events';
 import StealthPlugin from '@zorilla/puppeteer-extra-plugin-stealth';
@@ -117,74 +117,81 @@ export class ChromiumCDP extends EventEmitter {
    * fires the request is in flight, so the teardown it used to trigger cost
    * the customer their session without preventing anything.
    *
-   * Interception is scoped to the blocklist's own URL shapes
-   * ({@link toBlockedUrlInterceptPatterns}), so ordinary traffic is never
-   * paused and never pays a round trip. Requests that do pause get the real
-   * verdict from {@link findBlockedNavigationUrl} — canonicalization,
-   * self-origin exemption and all — which is why the patterns can afford to
-   * over-match.
+   * Blocking is `Network.setBlockedURLs`. The obvious alternative — pausing
+   * requests with `Fetch` and asking {@link findBlockedNavigationUrl} for a
+   * verdict — is what this replaced: enabling `Fetch` on a second CDP session
+   * swallows the auth challenge for every request on the target, so a client's
+   * `page.authenticate()` is never asked for credentials and the navigation
+   * fails with `ERR_INVALID_AUTH_CREDENTIALS` (PLT-1596). That happens whether
+   * or not any request matches our patterns, and `handleAuthRequests` is no
+   * answer: we would then own challenges we have no credentials for.
    *
-   * Deliberately `Fetch` rather than `Network.setBlockedURLs`: the latter
-   * matches globs with no notion of an exemption, so blocking `localhost`
-   * would also block the server's own origin and break the pages browserless
-   * serves itself. This runs on its own CDP session and chains with a client's
-   * own `setRequestInterception` (verified) instead of displacing it.
+   * The patterns therefore carry the whole policy, self-origin exemption
+   * included — see {@link toBlockedUrlPatterns}. What they cannot cover is
+   * navigations and WebSocket handshakes, which `setBlockedURLs` does not
+   * apply to (measured); those stay with the route-level 403, the
+   * wire-protocol check, and the observational teardown below.
+   *
+   * The blocklist is read once per page rather than once per request, so a
+   * config change reaches the next page rather than the next request; the
+   * observational backstop below still re-reads it every time.
+   *
+   * Set on the session puppeteer already drives the page with, not a fresh
+   * one: a second session has to `Target.attachToTarget` (which failed often
+   * enough in production to leave pages unguarded) and would carry a second
+   * copy of every `Network` event for the life of the page.
    */
   protected async installBlockedUrlGuard(page: Page): Promise<void> {
-    const patterns = this.config.getBlockedURLPatterns();
-    const ranges = this.config.getBlockedNetworkRanges();
-    const interceptPatterns = toBlockedUrlInterceptPatterns(patterns, ranges);
+    const blockedUrls = toBlockedUrlPatterns(
+      this.config.getBlockedURLPatterns(),
+      this.config.getBlockedNetworkRanges(),
+      this.config.getSelfNavigationHosts(),
+    );
 
-    if (!interceptPatterns.length) {
+    if (!blockedUrls.length) {
       return;
     }
 
-    const session = await page.createCDPSession().catch((err) => {
-      this.logger.error(`Could not attach the blocked-URL guard: ${err}`);
-      return null;
-    });
+    const session = await this.pageSession(page);
 
     if (!session) {
       return;
     }
 
-    session.on('Fetch.requestPaused', async ({ requestId, request }) => {
-      // Re-read config per request: it can change at runtime, and the verdict
-      // must come from the matcher rather than from the coarse patterns that
-      // decided to pause.
-      const blocked = findBlockedNavigationUrl(
-        request.url,
-        this.config.getBlockedURLPatterns(),
-        this.config.getBlockedNetworkRanges(),
-        this.config.getSelfNavigationHosts(),
-      );
-
-      if (blocked) {
-        this.logger.debug(`Failing request to blocked URL "${request.url}"`);
-      }
-
-      // Either arm must answer, or the request hangs until the protocol
-      // timeout. A detached session (page already closed) throws on send,
-      // which is the expected way this unwinds rather than an error.
-      await session
-        .send(
-          blocked ? 'Fetch.failRequest' : 'Fetch.continueRequest',
-          blocked
-            ? { errorReason: 'BlockedByClient', requestId }
-            : { requestId },
-        )
-        .catch(noop);
-    });
-
+    // `Network` is already enabled on puppeteer's own session — the page
+    // events below depend on it — but the guard is inert without it, so say so
+    // rather than inherit it. Both calls are idempotent.
     await session
-      .send('Fetch.enable', {
-        patterns: interceptPatterns.map((urlPattern: string) => ({
-          urlPattern,
-        })),
-      })
+      .send('Network.enable')
+      .then(() => session.send('Network.setBlockedURLs', { urls: blockedUrls }))
       .catch((err) => {
         this.logger.error(`Could not enable the blocked-URL guard: ${err}`);
       });
+  }
+
+  /**
+   * The CDP session puppeteer already drives `page` on. `Frame.client` is
+   * public at runtime but absent from puppeteer's exported `Frame` type, so it
+   * needs the cast; a puppeteer that drops it falls back to a session of our
+   * own, which costs a duplicate event stream but still guards the page.
+   */
+  protected async pageSession(page: Page): Promise<CDPSession | null> {
+    try {
+      const client = (page.mainFrame() as unknown as { client?: CDPSession })
+        .client;
+
+      if (client) {
+        return client;
+      }
+    } catch {
+      // A page that closed between 'targetcreated' and here has no frame to
+      // read it from; the attach below reports its own failure.
+    }
+
+    return page.createCDPSession().catch((err) => {
+      this.logger.error(`Could not attach the blocked-URL guard: ${err}`);
+      return null;
+    });
   }
 
   protected async onTargetCreated(target: Target) {
@@ -195,9 +202,7 @@ export class ChromiumCDP extends EventEmitter {
       });
 
       if (page) {
-        this.logger.trace(`Setting up blocked-URL request rejection`);
-
-        await this.installBlockedUrlGuard(page);
+        this.logger.trace(`Setting up blocked-URL request blocking`);
 
         page.on('error', (err) => {
           this.logger.error(err);
@@ -290,6 +295,13 @@ export class ChromiumCDP extends EventEmitter {
             response.request().isNavigationRequest(),
           );
         });
+
+        // Installed last, and deliberately: the handlers above are attached
+        // synchronously, so nothing a page does in the round trips this takes
+        // can slip past unobserved. Putting the install first left the backstop
+        // blind to the first navigation of a page — long enough for a client to
+        // read a file:// document before the teardown reached it.
+        await this.installBlockedUrlGuard(page);
 
         this.emit('newPage', page);
       }

--- a/src/network-security.spec.ts
+++ b/src/network-security.spec.ts
@@ -6,7 +6,8 @@ import {
   isBlockedNavigationIP,
   isBlockedNavigationUrl,
   looksLikeIPv4Literal,
-  toBlockedUrlInterceptPatterns,
+  matchesBlockedUrlPattern,
+  toBlockedUrlPatterns,
 } from '@browserless.io/browserless';
 
 // A representative opt-in range set: loopback, link-local/cloud-metadata,
@@ -297,30 +298,48 @@ describe('Network Security', () => {
       ).to.be.null;
     });
   });
-  describe('toBlockedUrlInterceptPatterns', () => {
-    // The patterns only decide what gets paused for a verdict, so the bar is
-    // "nothing the matcher would reject can slip past unpaused". Over-matching
-    // is the intended trade: a wrongly-paused request is continued unchanged.
-    const matches = (pattern: string, url: string): boolean =>
-      new RegExp(
-        `^${pattern
-          .split('*')
-          .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-          .join('.*')}$`,
-      ).test(url);
+  describe('toBlockedUrlPatterns', () => {
+    // These patterns are the verdict — nothing pauses to ask the matcher
+    // afterwards — so both directions matter: everything the classifier blocks
+    // has to be covered, and ordinary traffic has to come through untouched.
+    const blocks = (url: string, patterns: string[]): boolean =>
+      patterns.some((pattern) => matchesBlockedUrlPattern(url, pattern));
 
-    const pauses = (url: string, patterns: string[]): boolean =>
-      patterns.some((pattern) => matches(pattern, url));
+    describe('matchesBlockedUrlPattern', () => {
+      // Chromium splits the pattern on `*` and looks for each piece in order,
+      // so a pattern is a substring test and cannot be anchored. Everything
+      // else in this file depends on that being what the browser does; the
+      // browser-level spec in browsers.cdp.spec.ts is what proves it.
+      it('matches each piece in order, anywhere in the URL', () => {
+        expect(matchesBlockedUrlPattern('http://127.0.0.1/x', '127.0.0.1')).to
+          .be.true;
+        expect(matchesBlockedUrlPattern('http://127.0.0.1/x', '*://127.0*')).to
+          .be.true;
+        expect(matchesBlockedUrlPattern('http://example.com/a/b', 'a/b')).to.be
+          .true;
+        expect(
+          matchesBlockedUrlPattern(
+            'http://127.0.0.1/localhost',
+            '*localhost*127.*',
+          ),
+          'pieces have to appear in the pattern order',
+        ).to.be.false;
+        expect(matchesBlockedUrlPattern('http://example.com/', 'nope')).to.be
+          .false;
+      });
+    });
 
-    it('pauses every URL the matcher blocks', () => {
-      const patterns = toBlockedUrlInterceptPatterns(['file://'], RANGES);
+    it('blocks every URL the matcher blocks', () => {
+      const patterns = toBlockedUrlPatterns(['file://'], RANGES);
 
       for (const url of [
         'file:///etc/passwd',
         'http://127.0.0.1/',
         'http://127.0.0.1:8888/wordpress/wp-content/uploads/svg/world-map.svg',
         'http://localhost:8888/x.svg',
+        'http://localhost/x.svg',
         'http://sub.localhost/x',
+        'http://sub.localhost:9000/x',
         'http://169.254.169.254/latest/meta-data/',
         'http://0.0.0.0:3000/',
         'http://172.16.0.1/',
@@ -329,15 +348,15 @@ describe('Network Security', () => {
         'smtp://127.0.0.1/',
         'ftp://example.com/',
       ]) {
-        expect(pauses(url, patterns), `should pause ${url}`).to.be.true;
+        expect(blocks(url, patterns), `should block ${url}`).to.be.true;
       }
     });
 
-    // Chromium hands the pattern matcher a URL with userinfo intact, so
-    // `*://127.*` does not match `http://user@127.0.0.1/` — the host is no
-    // longer where the glob expects it.
-    it('pauses hosts hidden behind userinfo', () => {
-      const patterns = toBlockedUrlInterceptPatterns(['file://'], RANGES);
+    // A credentialed URL puts userinfo where the scheme separator would
+    // otherwise sit right in front of the host, so every host-shaped pattern
+    // needs its `@` twin or the host hides behind the credentials.
+    it('blocks hosts hidden behind userinfo', () => {
+      const patterns = toBlockedUrlPatterns(['file://'], RANGES);
 
       for (const url of [
         'http://user@127.0.0.1/',
@@ -348,45 +367,140 @@ describe('Network Security', () => {
         'http://user@[::1]:8080/',
         'smtp://user@127.0.0.1/',
       ]) {
-        expect(pauses(url, patterns), `should pause ${url}`).to.be.true;
+        expect(blocks(url, patterns), `should block ${url}`).to.be.true;
       }
     });
 
-    it('leaves ordinary traffic unpaused', () => {
-      const patterns = toBlockedUrlInterceptPatterns(['file://'], RANGES);
+    // The reason the patterns are anchored rather than the plain prefixes the
+    // `Fetch` guard could afford: with no per-request verdict behind them, a
+    // lookalike host that matches is a customer's sub-resource that silently
+    // fails. `0.gravatar.com` is the one that matters — it sits on a great
+    // many WordPress sites, which is exactly the population PLT-1572 came
+    // from.
+    it('leaves lookalike hosts alone', () => {
+      const patterns = toBlockedUrlPatterns(['file://'], RANGES);
 
       for (const url of [
         'https://example.com/index.html',
         'https://careers.kinly.com/o/av-event-technician-38',
+        'https://0.gravatar.com/avatar/abc123',
+        'https://2.gravatar.com/avatar/abc123',
+        'https://localhostings.com/',
+        'https://127.example.com/',
+        'https://172.16.example.com/',
         'https://cdn.example.com/app.js?v=127',
         'https://10.0.0.1.example.com/',
         'https://user@example.com/dashboard',
       ]) {
-        expect(pauses(url, patterns), `should not pause ${url}`).to.be.false;
+        expect(blocks(url, patterns), `should not block ${url}`).to.be.false;
       }
     });
 
-    // The userinfo twins widen the globs: a path segment containing '@' can
-    // now pause a perfectly ordinary URL. That is the accepted trade — pausing
-    // is not blocking, and the matcher is what decides.
-    it('over-matches harmlessly: a paused public URL is still allowed', () => {
-      const url = 'https://cdn.example.com/u/a@127.example.org/logo.png';
-      const patterns = toBlockedUrlInterceptPatterns(['file://'], RANGES);
+    describe('the self-origin carve-out', () => {
+      // What `Network.setBlockedURLs` cannot express is an exemption, and the
+      // server's own origin needs one: the /function runtime's code is a
+      // sub-resource of a page served from it, and blocking beats interception
+      // to the request. Carving the origin out of the patterns is the whole
+      // reason this file computes a match itself.
+      const SELF = ['localhost:3000'];
 
-      expect(pauses(url, patterns), 'over-matched by the glob').to.be.true;
-      expect(findBlockedNavigationUrl(url, ['file://'], RANGES)).to.be.null;
+      it("lets the server's own origin through", () => {
+        const patterns = toBlockedUrlPatterns(['file://'], RANGES, SELF);
+
+        for (const url of [
+          'http://localhost:3000/',
+          'http://localhost:3000/function/index.html',
+          'http://localhost:3000/function/browserless-function-abc.js',
+          'ws://localhost:3000/function/connect/abc?token=t',
+        ]) {
+          expect(blocks(url, patterns), `should allow ${url}`).to.be.false;
+        }
+      });
+
+      // The point of doing this per character rather than by dropping the
+      // colliding pattern outright: PLT-1572's own customer case is
+      // `http://localhost:8888/…`, which a dropped `localhost` pattern would
+      // stop blocking.
+      it('still blocks every other port on the same host', () => {
+        const patterns = toBlockedUrlPatterns(['file://'], RANGES, SELF);
+
+        for (const url of [
+          'http://localhost:8888/x.svg',
+          'http://localhost:3001/x',
+          'http://localhost:30001/x',
+          'http://localhost:300/x',
+          'http://localhost:30/x',
+          'http://localhost:3/x',
+          'http://localhost/x',
+          'http://localhost:22/',
+          'http://sub.localhost:3000/x',
+          'http://127.0.0.1:3000/x',
+        ]) {
+          expect(blocks(url, patterns), `should block ${url}`).to.be.true;
+        }
+      });
+
+      it('carves out an IP-literal self host without losing the range', () => {
+        const patterns = toBlockedUrlPatterns(['file://'], RANGES, [
+          '127.0.0.1:3000',
+        ]);
+
+        expect(blocks('http://127.0.0.1:3000/function/code.js', patterns)).to.be
+          .false;
+        for (const url of [
+          'http://127.0.0.1:8888/x',
+          'http://127.0.0.1/x',
+          'http://127.0.0.2:3000/x',
+          'http://127.1.0.1:3000/x',
+          'http://169.254.169.254/',
+          'http://localhost:3000/x',
+        ]) {
+          expect(blocks(url, patterns), `should block ${url}`).to.be.true;
+        }
+      });
+
+      it('carves out a self host bound to a default port', () => {
+        const patterns = toBlockedUrlPatterns(['file://'], RANGES, [
+          'localhost',
+        ]);
+
+        expect(blocks('http://localhost/function/code.js', patterns)).to.be
+          .false;
+        expect(blocks('http://localhost:8888/x', patterns)).to.be.true;
+        expect(blocks('http://sub.localhost/x', patterns)).to.be.true;
+      });
+
+      it('carves out every self host it is given', () => {
+        const patterns = toBlockedUrlPatterns(['file://'], RANGES, [
+          'localhost:3000',
+          '127.0.0.1:3000',
+        ]);
+
+        expect(blocks('http://localhost:3000/x', patterns)).to.be.false;
+        expect(blocks('http://127.0.0.1:3000/x', patterns)).to.be.false;
+        expect(blocks('http://localhost:8888/x', patterns)).to.be.true;
+        expect(blocks('http://127.0.0.1:8888/x', patterns)).to.be.true;
+      });
+
+      // A self host outside the blocklist changes nothing — no pattern matches
+      // it, so none is rewritten.
+      it('leaves the patterns alone when nothing collides', () => {
+        expect(
+          toBlockedUrlPatterns(['file://'], RANGES, ['example.com:3000']),
+        ).to.deep.equal(toBlockedUrlPatterns(['file://'], RANGES));
+      });
     });
 
     it('returns [] when nothing is configured to block', () => {
-      expect(toBlockedUrlInterceptPatterns([], null)).to.deep.equal([]);
+      expect(toBlockedUrlPatterns([], null)).to.deep.equal([]);
     });
 
     it('covers the scheme blocklist on its own when ranges are disabled', () => {
-      const patterns = toBlockedUrlInterceptPatterns(['file://'], null);
+      const patterns = toBlockedUrlPatterns(['file://'], null);
 
-      expect(patterns).to.deep.equal(['file://*']);
-      expect(pauses('file:///etc/passwd', patterns)).to.be.true;
-      expect(pauses('https://example.com/', patterns)).to.be.false;
+      expect(patterns).to.deep.equal(['file://']);
+      expect(blocks('file:///etc/passwd', patterns)).to.be.true;
+      expect(blocks('https://example.com/', patterns)).to.be.false;
     });
   });
 });

--- a/src/network-security.ts
+++ b/src/network-security.ts
@@ -189,69 +189,184 @@ export const assertNavigationAllowed = (
 };
 
 /**
- * Builds the `Fetch.enable` URL patterns that decide which requests are paused
- * for a blocklist verdict. Everything the matcher could reject must match one
- * of these — a request that is never paused is never checked — so the patterns
- * deliberately over-match and leave the real decision to
- * {@link findBlockedNavigationUrl}, which canonicalizes and understands the
- * self-origin exemption. A pause that resolves to "allowed" costs one
- * `Fetch.continueRequest`; a miss costs the guard entirely.
+ * Chromium matches a `Network.setBlockedURLs` pattern by splitting it on `*`
+ * and requiring each piece to appear in the URL in order, so a pattern with no
+ * `*` is a plain substring test and there is no way to anchor one to the start
+ * or the end of the URL. Mirrored here so {@link toBlockedUrlPatterns} can work
+ * out which of its own patterns would swallow the server's own origin, under
+ * exactly the rules the browser will apply.
+ */
+export const matchesBlockedUrlPattern = (
+  url: string,
+  pattern: string,
+): boolean => {
+  let from = 0;
+  for (const piece of pattern.split('*')) {
+    if (!piece) continue;
+    const at = url.indexOf(piece, from);
+    if (at === -1) return false;
+    from = at + piece.length;
+  }
+  return true;
+};
+
+// A host sits between the scheme separator (or the userinfo, in a credentialed
+// URL) and either its port or the path. Against a matcher with no anchors of
+// its own, those four strings are the only way to say "this is the host".
+const HOST_STARTS = ['://', '@'] as const;
+const HOST_ENDS = ['/', ':'] as const;
+// `url.spec()` always carries a path, so a host is always followed by `/` or
+// `:` — a pattern never has to consider `?` or `#` sitting directly after it.
+const PATH_END = '/';
+const DIGITS = '0123456789';
+// What can follow a partial match inside a blocked origin: more of the host
+// (IPv4 literals are digits and dots), or the port.
+const HOST_CHARS = `${DIGITS}.:`;
+
+/**
+ * Every spelling of a blocked hostname, anchored at both ends. The classifier
+ * blocks the name itself and any sub-domain of it, and the anchors are what
+ * keep `localhost` from also blocking `localhostings.com` — a substring
+ * matcher would otherwise treat the lookalike as a hit.
+ */
+const hostnamePatterns = (hostname: string): string[] => [
+  ...HOST_STARTS.flatMap((start) =>
+    HOST_ENDS.map((end) => `${start}${hostname}${end}`),
+  ),
+  // Sub-domains: the leading dot anchors these on its own, credentials or not.
+  ...HOST_ENDS.map((end) => `.${hostname}${end}`),
+];
+
+/**
+ * An IPv4 prefix, with a digit pinned after it. The digit is what stops `0.`
+ * from also blocking `0.gravatar.com` — a real host on a great many WordPress
+ * sites, which is exactly the sort of page this guard runs against. Chromium
+ * canonicalizes decimal (`http://2130706433/`) and hex (`http://0x7f.0.0.1/`)
+ * forms to dotted-quad before matching, so only the canonical spelling needs
+ * listing.
+ */
+const ipv4Patterns = (prefix: string): string[] =>
+  [...DIGITS].flatMap((digit) =>
+    HOST_STARTS.map((start) => `${start}${prefix}${digit}`),
+  );
+
+/**
+ * An IPv6 prefix. The opening bracket anchors these as literals, so no
+ * hostname can collide with them and no closing anchor is needed.
+ */
+const ipv6Patterns = (prefix: string): string[] =>
+  HOST_STARTS.map((start) => `${start}[${prefix}`);
+
+/**
+ * Rewrites one pattern into the set that matches everything it did except the
+ * server's own origin.
  *
- * Over-matching is why these are not the blocklist itself: `*://127.*` also
- * pauses `http://127.example.com/`, and `*://localhost*` also pauses
- * `https://localhostings.com/` — both continue on unchanged once the matcher
- * has looked at them.
+ * `Network.setBlockedURLs` has no notion of an exemption, and the original
+ * `Fetch`-based guard leaned on that: it paused a request and let
+ * {@link findBlockedNavigationUrl} decide, self-origin carve-out included.
+ * Pausing is what broke `page.authenticate()`, so the carve-out has to be
+ * expressed in the patterns themselves.
  *
- * Chromium canonicalizes a URL before matching, so decimal (`http://2130706433/`)
- * and hex (`http://0x7f.0.0.1/`) IPv4 forms arrive here already spelled as
- * dotted-quad and are caught by the numeric prefixes. IPv6 literals are covered
- * wholesale by `*://[*` rather than per-prefix, since the bracket form is rare
- * enough that pausing all of it is cheaper than getting the prefixes right.
+ * It can be, because a URL that is not our origin has to differ from it at
+ * some character: one pattern per (position, alternative character) covers all
+ * of them and none of ours. For a server on `localhost:3000` that is ~50
+ * patterns — `://localhost:8`, `://localhost:30/`, `://localhost:3001`, and so
+ * on — which still block every other port on the host while leaving the pages
+ * browserless serves itself (the `/function` runtime and its own WebSocket)
+ * reachable.
+ */
+const withoutSelfOrigin = (pattern: string, origin: string): string[] => {
+  const at = origin.indexOf(pattern);
+
+  // Only a literal pattern can be taken apart this way. A wildcard one that
+  // reaches our own origin is dropped instead: refusing to guard that shape
+  // costs one blocklist entry, while decomposing from the wrong offset would
+  // emit patterns like `/` and block every request the browser makes.
+  if (at === -1) {
+    return [];
+  }
+
+  const consumed = at + pattern.length;
+  // The port's colon, skipping both the scheme separator and the colons inside
+  // an IPv6 literal.
+  const bracketEnd = origin.lastIndexOf(']');
+  const portAt = origin.indexOf(':', bracketEnd > 0 ? bracketEnd : 3);
+  const out: string[] = [];
+
+  for (let index = consumed; index < origin.length; index++) {
+    const inPort = portAt !== -1 && index > portAt;
+    // A port has to start with a digit, so `/` is only an alternative once at
+    // least one digit of it is fixed; anywhere else it means "the origin ends
+    // here", which is a different origin from ours.
+    const alternatives =
+      (inPort ? DIGITS : HOST_CHARS) +
+      (index === portAt + 1 && inPort ? '' : PATH_END);
+
+    for (const char of alternatives) {
+      if (char === origin[index]) continue;
+      // Rebuilt from the pattern, not from the origin, so a pattern that
+      // matched partway in keeps its own anchor: a `.localhost:` rewritten
+      // around a self host of `sub.localhost:3000` still covers every other
+      // sub-domain, which re-anchoring on `://sub` would have dropped.
+      out.push(pattern + origin.slice(consumed, index) + char);
+    }
+  }
+
+  return out;
+};
+
+/**
+ * Builds the patterns handed to `Network.setBlockedURLs`, which is how the CDP
+ * guard stops a page reaching a blocked destination.
  *
- * Userinfo is NOT canonicalized away: a navigation to
- * `http://user@127.0.0.1/` reaches the pattern matcher with the credentials
- * still in the string, where `*://127.*` does not match because `user@` sits
- * between the scheme and the host. Every host-shaped glob therefore gets a
- * `*://*@…` twin. (Credentialed *sub-resources* never get this far — Chromium
- * blocks them outright — but a credentialed navigation does, and without the
- * twin it would slip past interception into the observational path, which can
- * only react once the request is already gone.)
+ * Unlike the `Fetch` patterns this replaced, these *are* the verdict: nothing
+ * pauses to ask {@link findBlockedNavigationUrl} afterwards, so they are
+ * written to match what the classifier blocks rather than to over-match and
+ * defer. Two consequences worth knowing:
+ *
+ * - Matching is a substring test (see {@link matchesBlockedUrlPattern}), so a
+ *   pattern can be anchored within the URL but never to its start. A scheme
+ *   pattern such as `file://` therefore also blocks a request whose *query*
+ *   carries an unencoded `file://`. Rare, and it costs one sub-resource.
+ * - `setBlockedURLs` does not apply to navigations or WebSocket handshakes
+ *   (measured). Navigations stay covered by the route-level 403, the
+ *   wire-protocol check in {@link findBlockedNavigationInMessage}, and the
+ *   observational teardown in the CDP browser class.
+ *
+ * `selfHosts` (`Config.getSelfNavigationHosts()`) is carved back out of the
+ * result rather than left to a per-request exemption — see
+ * {@link withoutSelfOrigin}.
  *
  * Returns `[]` when nothing is configured to block, which callers should treat
- * as "do not enable interception at all".
+ * as "do not install the guard at all".
  */
-export const toBlockedUrlInterceptPatterns = (
+export const toBlockedUrlPatterns = (
   patterns: string[],
   ranges: NetworkRangeSet | null,
+  selfHosts: readonly string[] = [],
 ): string[] => {
-  const globs = new Set<string>();
+  const built: string[] = [
+    // Scheme blocklists (`file://`) and blocked protocols (`smtp://`, `ftp://`)
+    // are already the head of the URL, so they need no anchoring of their own.
+    ...patterns,
+    ...(ranges?.protocols ?? []),
+    ...(ranges?.hostnames ?? []).flatMap(hostnamePatterns),
+    ...(ranges?.ipv4Prefixes ?? []).flatMap(ipv4Patterns),
+    ...(ranges?.ipv6Prefixes ?? []).flatMap(ipv6Patterns),
+  ];
 
-  // Scheme blocklists (`file://`) and blocked protocols (`smtp://`, `ftp://`)
-  // are already prefixes of the URL, so they need only a trailing wildcard —
-  // userinfo sits after the scheme, so these cover the credentialed form too.
-  for (const pattern of [...patterns, ...(ranges?.protocols ?? [])]) {
-    globs.add(`${pattern}*`);
-  }
+  // The origins the browser has to keep reaching. A self host never carries
+  // credentials, so only the `://` spelling can collide.
+  const origins = selfHosts.map((host) => `://${host}/`);
+  const exempted = origins.reduce(
+    (current, origin) =>
+      current.flatMap((pattern) =>
+        matchesBlockedUrlPattern(origin, pattern)
+          ? withoutSelfOrigin(pattern, origin)
+          : [pattern],
+      ),
+    built,
+  );
 
-  // Both spellings of a host-shaped glob: bare, and with userinfo ahead of it.
-  const addHostGlob = (host: string) => {
-    globs.add(`*://${host}*`);
-    globs.add(`*://*@${host}*`);
-  };
-
-  if (ranges) {
-    for (const prefix of ranges.ipv4Prefixes) {
-      addHostGlob(prefix);
-    }
-    if (ranges.ipv6Prefixes.length) {
-      addHostGlob('[');
-    }
-    for (const hostname of ranges.hostnames) {
-      // The host itself, plus the dot-suffix form the classifier also blocks.
-      addHostGlob(hostname);
-      addHostGlob(`*.${hostname}`);
-    }
-  }
-
-  return [...globs];
+  return [...new Set(exempted)];
 };


### PR DESCRIPTION
Fixes [PLT-1596](https://linear.app/browserless/issue/PLT-1596/blocked-url-fetch-guard-breaks-pageauthenticate-err-invalid-auth). Re-implements the PLT-1572 blocked-URL guard so it no longer breaks `page.authenticate()`.

## The bug

`installBlockedUrlGuard` (#5562, 2.56.3) opened a second CDP session per page and called `Fetch.enable` on it. Enabling `Fetch` anywhere on a target hands that target's auth challenges to the interceptor, so a client's `page.authenticate()` was never asked for credentials and Chromium failed the navigation with `net::ERR_INVALID_AUTH_CREDENTIALS` — site (401) and proxy (407) alike, e.g. `/chrome?--proxy-server=…` with the credentials supplied by the client rather than the flag.

It fired whether or not anything matched the guard's patterns, which is why a sequential test passed review and ~5% of one customer's sessions did not.

Measured while writing this, so the alternatives are ruled out rather than assumed:

| guard | client `page.authenticate()` |
| -- | -- |
| none | ok, ok, ok |
| `Fetch.enable`, patterns matching nothing | `ERR_INVALID_AUTH_CREDENTIALS` ×3 |
| `Fetch.enable` + `handleAuthRequests`, answering `Default` | `ERR_INVALID_AUTH_CREDENTIALS` ×3 (our session never even sees `Fetch.authRequired`) |
| `Network.setBlockedURLs` | ok, ok, ok |

## The fix

Blocking moves to `Network.setBlockedURLs`, which leaves auth alone. Two consequences, both handled here:

**The patterns are now the verdict.** Nothing pauses to ask `findBlockedNavigationUrl` afterwards, so they have to be anchored instead of over-matching and deferring. Chromium matches a pattern by splitting it on `*` and looking for each piece in order — an unanchored substring test — so `0.` would block `0.gravatar.com` (on a great many WordPress sites, which is the population PLT-1572 came from) and `localhost` would block `localhostings.com`. Patterns are now `://localhost/`, `://localhost:`, `.localhost:`, `://127.0`…`://127.9`, `://[::1`, plus an `@` twin of each for credentialed URLs.

**`setBlockedURLs` has no exemption, and the server's own origin needs one.** The `/function` runtime's code is a sub-resource of a page served from that origin, and blocking beats interception to the request — so with a naive pattern set the runtime stops booting (verified). The carve-out is computed into the patterns instead: a URL that is not our origin differs from it at some character, so one pattern per (position, alternative character) covers everything else. For `localhost:3000` that is ~50 patterns and every other port on the host stays blocked — including PLT-1572's own `http://localhost:8888/…`, which dropping the colliding pattern outright would have unblocked.

## What this gives up, and what covers it

`setBlockedURLs` does not apply to navigations or WebSocket handshakes — measured, `file://` navigations included. Navigations therefore keep the layering they already had: the route-level 403, the wire-protocol check in `findBlockedNavigationInMessage`, and the observational teardown. That is the 2.56.2 posture for navigations; sub-resources (the PLT-1572 cases) are blocked outright as in 2.56.3.

Two things fell out of testing that posture:

- **The teardown was attached too late.** `await installBlockedUrlGuard(page)` ran *before* the `page.on('request')` handlers, so the backstop could miss the first navigation of a page entirely — long enough for a client to `page.goto('file:///etc/passwd')` and read it. The existing `rejects file protocol requests` route specs catch this; they pass at 2.56.2, fail without this reorder, and pass with it (5/5). The handlers are synchronous, so they now go on first and the install is awaited last.
- **The guard sets the blocklist on the session puppeteer already drives the page with**, rather than attaching its own. No `Target.attachToTarget` to fail — the `Could not attach the blocked-URL guard: ProtocolError` fingerprint appeared 315 times in production, each one a page left unguarded — and no second copy of every `Network` event for the life of the page (measured: 72 events per 11 requests on the extra session).

## Tests

- `page.authenticate()` against a 401 site (three sequential pages, since the original was a race) and a 407 proxy, both driven from a second puppeteer connection as in production. **Both fail with `ERR_INVALID_AUTH_CREDENTIALS` on pre-fix code and pass with the fix** — verified by reverting the two source files and re-running.
- Lookalike hosts (`0.gravatar.*`, `localhostings.*`, `127.example.*`) load, asserted through the real browser rather than against a re-implementation of the matcher.
- The self-origin carve-out: own origin reachable, every other port on the same host blocked, IP-literal and default-port self hosts, multiple self hosts.
- PLT-1572's cases re-verified: the Word-pasted `file://` image and the stale `localhost:8888` image still leave the session alive, and the `localhost` image still never reaches its destination.

Full suite green, lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network protection so blocked URL patterns are enforced more consistently.
  * Preserved access to configured application hosts while blocking matching external destinations.
  * Improved handling of userinfo-hidden hosts, alternate ports, IP addresses, and IPv6 addresses.
  * Prevented lookalike hostnames from being incorrectly treated as trusted.
  * Improved authentication handling for protected sites and proxy connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->