### PR TITLE
fix: block IPv4 prefixes without a trailing dot

### DIFF
--- a/src/network-security.spec.ts
+++ b/src/network-security.spec.ts
@@ -426,6 +426,32 @@ describe('Network Security', () => {
         expect(blocks('https://example.com/', patterns)).to.be.false;
       });
 
+      // The dot that ends an octet has to carry a digit. A bare one would
+      // match a name that merely starts with the prefix, and the classifier
+      // does not: prefix-matching applies to hosts that are all digits and
+      // dots, so `169.254.example.com` is an ordinary name it allows.
+      it('leaves a DNS host that starts with the prefix alone', () => {
+        for (const [prefix, url] of [
+          ['169.254', 'http://169.254.example.com/'],
+          ['169.254', 'https://169.254.customer.io/assets/logo.svg'],
+          ['127.0.0.1', 'http://127.0.0.1.example.com/'],
+          ['172.16.', 'http://172.16.example.com/'],
+        ]) {
+          const patterns = fromPrefixes([prefix]);
+
+          expect(blocks(url, patterns), `should not block ${url}`).to.be.false;
+          expect(
+            isBlockedNavigationUrl(url, {
+              hostnames: [],
+              ipv4Prefixes: [prefix],
+              ipv6Prefixes: [],
+              protocols: [],
+            }),
+            `the matcher these mirror should not block ${url} either`,
+          ).to.be.false;
+        }
+      });
+
       // A prefix can also be a whole address, which has to let the host end
       // rather than only continue.
       it('blocks a prefix that is a complete address', () => {

--- a/src/network-security.spec.ts
+++ b/src/network-security.spec.ts
@@ -396,6 +396,52 @@ describe('Network Security', () => {
       }
     });
 
+    // Every prefix in this file's RANGES ends at a dot boundary, and that is
+    // what let the first version of these patterns ship broken: enterprise
+    // spells the cloud-metadata range `169.254`, with no trailing dot, and a
+    // digit-only anchor turned it into `://169.2540`…`://169.2549` — patterns
+    // that cannot match `169.254.169.254`. The range read as configured and
+    // blocked nothing, which is the worst way for a blocklist to fail.
+    describe('prefixes that do not end at a dot boundary', () => {
+      const fromPrefixes = (prefixes: string[]) =>
+        toBlockedUrlPatterns([], {
+          hostnames: [],
+          ipv4Prefixes: prefixes,
+          ipv6Prefixes: [],
+          protocols: [],
+        });
+
+      it('blocks a prefix that stops mid-octet, as enterprise spells it', () => {
+        const patterns = fromPrefixes(['169.254']);
+
+        for (const url of [
+          'http://169.254.169.254/latest/meta-data/',
+          'http://169.254.169.254/',
+          'http://169.254.1.1/',
+          'http://user@169.254.169.254/',
+          'http://169.254.169.254:8080/',
+        ]) {
+          expect(blocks(url, patterns), `should block ${url}`).to.be.true;
+        }
+        expect(blocks('https://example.com/', patterns)).to.be.false;
+      });
+
+      // A prefix can also be a whole address, which has to let the host end
+      // rather than only continue.
+      it('blocks a prefix that is a complete address', () => {
+        const patterns = fromPrefixes(['127.0.0.1']);
+
+        for (const url of [
+          'http://127.0.0.1/',
+          'http://127.0.0.1/x',
+          'http://127.0.0.1:8080/x',
+          'http://127.0.0.10/x',
+        ]) {
+          expect(blocks(url, patterns), `should block ${url}`).to.be.true;
+        }
+      });
+    });
+
     describe('the self-origin carve-out', () => {
       // What `Network.setBlockedURLs` cannot express is an exemption, and the
       // server's own origin needs one: the /function runtime's code is a

--- a/src/network-security.ts
+++ b/src/network-security.ts
@@ -258,7 +258,16 @@ const ipv4Patterns = (prefix: string): string[] => {
   const continuations = prefix.endsWith('.')
     ? // Already at a dot boundary, so only another octet can follow.
       [...DIGITS]
-    : [...DIGITS, '.', ...HOST_ENDS];
+    : [
+        // The rest of the octet, the octet after it, or the end of the host.
+        // The dot carries a digit rather than standing alone: the classifier
+        // only prefix-matches hosts that are all digits and dots, so a bare
+        // `://169.254.` would also block `169.254.example.com`, which it
+        // treats as an ordinary name and allows.
+        ...DIGITS,
+        ...[...DIGITS].map((digit) => `.${digit}`),
+        ...HOST_ENDS,
+      ];
 
   return continuations.flatMap((continuation) =>
     HOST_STARTS.map((start) => `${start}${prefix}${continuation}`),

--- a/src/network-security.ts
+++ b/src/network-security.ts
@@ -238,17 +238,32 @@ const hostnamePatterns = (hostname: string): string[] => [
 ];
 
 /**
- * An IPv4 prefix, with a digit pinned after it. The digit is what stops `0.`
- * from also blocking `0.gravatar.com` — a real host on a great many WordPress
- * sites, which is exactly the sort of page this guard runs against. Chromium
- * canonicalizes decimal (`http://2130706433/`) and hex (`http://0x7f.0.0.1/`)
- * forms to dotted-quad before matching, so only the canonical spelling needs
- * listing.
+ * An IPv4 prefix, with the characters that can legitimately follow it pinned
+ * after it. Pinning is what stops `0.` from also blocking `0.gravatar.com` — a
+ * real host on a great many WordPress sites, which is exactly the sort of page
+ * this guard runs against. Chromium canonicalizes decimal
+ * (`http://2130706433/`) and hex (`http://0x7f.0.0.1/`) forms to dotted-quad
+ * before matching, so only the canonical spelling needs listing.
+ *
+ * What may follow depends on where the prefix stops, and getting it wrong is
+ * silent. The classifier prefix-matches the host, so a prefix that stops
+ * mid-octet — `169.254`, which is how enterprise spells the cloud-metadata
+ * range — continues with the rest of that octet *or* with the dot that ends
+ * it. Pinning only a digit there yields `://169.2540`…`://169.2549`, none of
+ * which can ever match `169.254.169.254`: the range reads as configured and
+ * blocks nothing. A prefix that is a whole address (`127.0.0.1`) likewise has
+ * to let the host end, hence the terminators.
  */
-const ipv4Patterns = (prefix: string): string[] =>
-  [...DIGITS].flatMap((digit) =>
-    HOST_STARTS.map((start) => `${start}${prefix}${digit}`),
+const ipv4Patterns = (prefix: string): string[] => {
+  const continuations = prefix.endsWith('.')
+    ? // Already at a dot boundary, so only another octet can follow.
+      [...DIGITS]
+    : [...DIGITS, '.', ...HOST_ENDS];
+
+  return continuations.flatMap((continuation) =>
+    HOST_STARTS.map((start) => `${start}${prefix}${continuation}`),
   );
+};
 
 /**
  * An IPv6 prefix. The opening bracket anchors these as literals, so no


### PR DESCRIPTION
## Problem

IPv4 network-blocking prefixes without a trailing dot, such as `169.254`, were converted into URL patterns that did not match the intended addresses. This could allow subresource requests to link-local addresses even when that range was configured as blocked.

## Changes

- Handle prefixes that end within an octet or represent a complete IPv4 address.
- Add regression coverage for link-local addresses, credentialed URLs, ports, and complete-address prefixes.
- Test DNS hostnames that resemble blocked prefixes.

## Validation

The existing GitHub Actions checks pass. Follow-up work is addressing an additional false positive for DNS hostnames with numeric labels, such as `169.254.1.example.com`.