### PR TITLE
fix: allow numeric DNS names through IPv4 URL guards

### DIFF
--- a/src/browsers/browsers.cdp.spec.ts
+++ b/src/browsers/browsers.cdp.spec.ts
@@ -8,7 +8,8 @@ import {
 import { Server, createServer } from 'http';
 import { AddressInfo } from 'net';
 import { expect } from 'chai';
-import puppeteer from 'puppeteer-core';
+import puppeteer, { Page } from 'puppeteer-core';
+import sinon from 'sinon';
 
 import { ChromiumCDP } from './browsers.cdp.js';
 
@@ -170,10 +171,13 @@ describe('ChromiumCDP blocked-URL guard', function () {
     }
   };
 
-  const launchGuarded = async (args: string[] = []) => {
+  const launchGuarded = async (
+    args: string[] = [],
+    config: Config = new GuardedConfig(),
+  ) => {
     browser = new ChromiumCDP({
       blockAds: false,
-      config: new GuardedConfig(),
+      config,
       logger: new Logger('browsers.cdp.spec'),
       userDataDir: null,
     });
@@ -188,8 +192,11 @@ describe('ChromiumCDP blocked-URL guard', function () {
     `--host-resolver-rules=MAP * 127.0.0.1:${port}`,
   ];
 
-  const newGuardedPage = async (args: string[] = []) => {
-    await launchGuarded(args);
+  const newGuardedPage = async (
+    args: string[] = [],
+    config: Config = new GuardedConfig(),
+  ) => {
+    await launchGuarded(args, config);
     const page = await browser!.newPage();
     // 'targetcreated' fires the guard install asynchronously, so newPage() can
     // resolve before the blocklist is live.
@@ -392,5 +399,117 @@ describe('ChromiumCDP blocked-URL guard', function () {
 
     expect(loaded(), 'lookalike hosts must load').to.equal(3);
     expect(browser!.isRunning()).to.be.true;
+  });
+
+  it('allows numeric DNS labels without exempting blocked addresses', async () => {
+    proxy!.removeAllListeners('request');
+    proxy!.on('request', (req, res) => {
+      hits.push(req.url ?? '');
+      res.writeHead(200, { 'content-type': 'image/svg+xml' });
+      res.end('<svg xmlns="http://www.w3.org/2000/svg"/>');
+    });
+    const page = await newGuardedPage([
+      `--proxy-server=127.0.0.1:${proxyPort}`,
+      '--proxy-bypass-list=<-loopback>',
+    ]);
+    const allowed = [
+      'http://169.254.1.example.test/logo.svg',
+      'http://127.0.0.1.example.test/path.1/',
+      'http://public.test/control.svg',
+    ];
+    const blocked = [
+      'http://169.254.169.254/latest/meta-data/',
+      'http://169.254.169.254/?host=example.test',
+      `http://127.0.0.1:${port}/blocked.svg`,
+      'http://sub.localhost:8888/blocked.svg',
+    ];
+
+    await page.evaluate(
+      async (urls) => {
+        await Promise.all(
+          urls.map(
+            (url) =>
+              new Promise<void>((resolve) => {
+                const image = new Image();
+                image.onload = image.onerror = () => resolve();
+                image.src = url;
+              }),
+          ),
+        );
+      },
+      [...allowed, ...blocked],
+    );
+
+    expect(hits.filter((url) => allowed.includes(url))).to.have.members(
+      allowed,
+    );
+    expect(hits.filter((url) => blocked.includes(url))).to.be.empty;
+    expect(browser!.isRunning()).to.be.true;
+  });
+
+  for (const pattern of ['http://', 'http://127.0.0.1.example.test/private']) {
+    it(`preserves the explicit URL block ${pattern}`, async () => {
+      class ExplicitConfig extends GuardedConfig {
+        public getBlockedURLPatterns(): string[] {
+          return ['file://', pattern];
+        }
+      }
+      const page = await newGuardedPage(
+        resolveEverythingLocally(),
+        new ExplicitConfig(),
+      );
+      const result = await page.evaluate(
+        () =>
+          new Promise<string>((resolve) => {
+            const image = new Image();
+            image.onload = () => resolve('loaded');
+            image.onerror = () => resolve('blocked');
+            image.src = 'http://127.0.0.1.example.test/private/logo.svg';
+          }),
+      );
+
+      expect(result).to.equal('blocked');
+      expect(hits).not.to.include('/private/logo.svg');
+    });
+  }
+
+  it('keeps blocking when ordered rules are unsupported', async () => {
+    class LegacyOnlyBrowser extends ChromiumCDP {
+      protected async pageSession(page: Page) {
+        const session = await super.pageSession(page);
+        if (session) {
+          // Simulate an older protocol, but let Chromium enforce every legacy
+          // command. The assertion is on real destination traffic.
+          sinon
+            .stub(session, 'send')
+            .callThrough()
+            .withArgs('Network.setBlockedURLs', sinon.match.has('urlPatterns'))
+            .rejects(new Error('Unsupported URL patterns'));
+        }
+        return session;
+      }
+    }
+    browser = new LegacyOnlyBrowser({
+      blockAds: false,
+      config: new GuardedConfig(),
+      logger: new Logger('browsers.cdp.spec'),
+      userDataDir: null,
+    });
+    await browser.launch({ options: { args: [] }, stealth: false });
+    const page = await browser.newPage();
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    const loaded = await page.evaluate(
+      (url) =>
+        new Promise<boolean>((resolve) => {
+          const image = new Image();
+          image.onload = () => resolve(true);
+          image.onerror = () => resolve(false);
+          image.src = url;
+        }),
+      `http://127.0.0.1:${port}/legacy-blocked.svg`,
+    );
+
+    expect(loaded).to.be.false;
+    expect(hits).not.to.include('/legacy-blocked.svg');
   });
 });

--- a/src/browsers/browsers.cdp.ts
+++ b/src/browsers/browsers.cdp.ts
@@ -11,6 +11,7 @@ import {
   noop,
   once,
   toBlockedUrlPatterns,
+  toBlockedUrlRules,
   ublockLitePath,
 } from '@browserless.io/browserless';
 import puppeteer, { Browser, CDPSession, Page, Target } from 'puppeteer-core';
@@ -142,11 +143,10 @@ export class ChromiumCDP extends EventEmitter {
    * copy of every `Network` event for the life of the page.
    */
   protected async installBlockedUrlGuard(page: Page): Promise<void> {
-    const blockedUrls = toBlockedUrlPatterns(
-      this.config.getBlockedURLPatterns(),
-      this.config.getBlockedNetworkRanges(),
-      this.config.getSelfNavigationHosts(),
-    );
+    const patterns = this.config.getBlockedURLPatterns();
+    const ranges = this.config.getBlockedNetworkRanges();
+    const selfHosts = this.config.getSelfNavigationHosts();
+    const blockedUrls = toBlockedUrlPatterns(patterns, ranges, selfHosts);
 
     if (!blockedUrls.length) {
       return;
@@ -164,6 +164,21 @@ export class ChromiumCDP extends EventEmitter {
     await session
       .send('Network.enable')
       .then(() => session.send('Network.setBlockedURLs', { urls: blockedUrls }))
+      .then(async () => {
+        const urlPatterns = toBlockedUrlRules(patterns, ranges, selfHosts);
+        if (urlPatterns.length) {
+          // Install the conservative list first. If an older browser rejects
+          // ordered rules, that list stays active on this same session.
+          await session
+            .send('Network.setBlockedURLs', {
+              urls: blockedUrls,
+              urlPatterns,
+            })
+            .catch((err) => {
+              this.logger.warn(`Using legacy blocked-URL patterns: ${err}`);
+            });
+        }
+      })
       .catch((err) => {
         this.logger.error(`Could not enable the blocked-URL guard: ${err}`);
       });

--- a/src/network-security.spec.ts
+++ b/src/network-security.spec.ts
@@ -8,7 +8,9 @@ import {
   looksLikeIPv4Literal,
   matchesBlockedUrlPattern,
   toBlockedUrlPatterns,
+  toBlockedUrlRules,
 } from '@browserless.io/browserless';
+import { URLPattern } from 'node:url';
 
 // A representative opt-in range set: loopback, link-local/cloud-metadata,
 // 0.0.0.0/8, the 172.16-31 RFC1918 block, dangerous IPv6, smtp/ftp, localhost.
@@ -573,6 +575,67 @@ describe('Network Security', () => {
       expect(patterns).to.deep.equal(['file://']);
       expect(blocks('file:///etc/passwd', patterns)).to.be.true;
       expect(blocks('https://example.com/', patterns)).to.be.false;
+    });
+  });
+
+  describe('toBlockedUrlRules', () => {
+    // Checks ordering and composition. The browser spec separately exercises
+    // Chromium's native matcher, which is not Node's URLPattern implementation.
+    it('preserves scheme, hostname, IP and self-port policy around DNS exceptions', () => {
+      const selfHosts = ['localhost:3000', '127.0.0.1:3000'];
+      const rules = toBlockedUrlRules(['file://'], RANGES, selfHosts);
+      const legacy = toBlockedUrlPatterns(['file://'], RANGES, selfHosts);
+
+      for (const [url, blocked] of [
+        ['http://169.254.1.example.test/logo.svg', false],
+        ['http://127.0.0.1.xn--bcher-kva.test/', false],
+        ['http://127.0.0.1.a_b.test/', false],
+        ['http://127.0.0.1.1-2/', false],
+        ['http://169.254.169.254/?host=example.test', true],
+        ['http://user@example.test@169.254.169.254/', true],
+        ['http://[fe80::a]:8080/', true],
+        ['http://sub.localhost:3000/', true],
+        ['http://localhost:3000/', false],
+        ['http://localhost:3001/', true],
+        ['http://127.0.0.1:3000/', false],
+        ['http://127.0.0.1:3001/', true],
+        ['file://169.254.1.example.test/private', true],
+        ['ftp://169.254.1.example.test/private', true],
+        ['ftp://localhost:3000/private', true],
+      ] as const) {
+        const normalized = new URL(url).href;
+        const rule = rules.find((rule) =>
+          new URLPattern(rule.urlPattern).test(normalized),
+        );
+        const actual =
+          rule?.block ??
+          legacy.some((pattern) =>
+            matchesBlockedUrlPattern(normalized, pattern),
+          );
+        expect(actual, url).to.equal(blocked);
+      }
+    });
+
+    it('retains legacy enforcement when policy cannot be translated safely', () => {
+      for (const patterns of [
+        ['file://', 'http://127.0.0.1.example.test/private'],
+        ['*private*'],
+        ['file:'],
+      ]) {
+        expect(toBlockedUrlRules(patterns, RANGES)).to.deep.equal([]);
+      }
+      for (const self of ['*.example.test', 'example.test:invalid', '[::1']) {
+        expect(toBlockedUrlRules([], RANGES, [self])).to.deep.equal([]);
+      }
+      for (const hostname of ['*.example.test', '127']) {
+        expect(
+          toBlockedUrlRules([], { ...RANGES, hostnames: [hostname] }),
+        ).to.deep.equal([]);
+      }
+      expect(toBlockedUrlRules(['file://'], null)).to.deep.equal([]);
+      expect(
+        toBlockedUrlRules([], { ...RANGES, ipv4Prefixes: [] }),
+      ).to.deep.equal([]);
     });
   });
 });

--- a/src/network-security.ts
+++ b/src/network-security.ts
@@ -394,3 +394,71 @@ export const toBlockedUrlPatterns = (
 
   return [...new Set(exempted)];
 };
+
+/**
+ * Ordered CDP rules that exempt dotted DNS names from IPv4 prefix matches.
+ * Chromium applies these before the legacy `urls` list, so scheme and hostname
+ * blocks must precede the exemptions. Arbitrary URL prefixes cannot be safely
+ * translated; those configurations keep their conservative legacy behavior.
+ *
+ * These are strings for Chromium's native matcher, not Node URLPattern objects.
+ * Keep the legacy list installed too: it enforces IPv4/IPv6 ranges and supplies
+ * the fallback on browsers without support for ordered rules.
+ */
+export const toBlockedUrlRules = (
+  patterns: string[],
+  ranges: NetworkRangeSet | null,
+  selfHosts: readonly string[] = [],
+): { urlPattern: string; block: boolean }[] => {
+  const schemes = [...patterns, ...(ranges?.protocols ?? [])];
+  if (
+    !ranges?.ipv4Prefixes.length ||
+    schemes.some((scheme) => !/^[a-z][a-z0-9+.-]*:\/\/$/.test(scheme)) ||
+    ranges.hostnames.some(
+      (hostname) => !/^[a-z0-9_-]+(?:\.[a-z0-9_-]+)*$/.test(hostname),
+    )
+  ) {
+    return [];
+  }
+
+  // URLPattern metacharacters must never turn a literal self host into a
+  // wildcard exemption. Noncanonical overrides retain the legacy guard.
+  try {
+    if (
+      selfHosts.some(
+        (host) =>
+          !/^[a-z0-9_.:[\]-]+$/.test(host) ||
+          new URL(`http://${host}`).host !== host,
+      ) ||
+      ranges.hostnames.some(
+        (hostname) => new URL(`http://${hostname}`).hostname !== hostname,
+      )
+    ) {
+      return [];
+    }
+  } catch {
+    return [];
+  }
+
+  return [
+    ...schemes.map((scheme) => ({
+      urlPattern: `${scheme}*:*/*`,
+      block: true,
+    })),
+    ...selfHosts.map((host) => ({
+      urlPattern: `*://${host}/*`,
+      block: false,
+    })),
+    ...ranges.hostnames.flatMap((hostname) => [
+      { urlPattern: `*://${hostname}:*/*`, block: true },
+      { urlPattern: `*://*.${hostname}:*/*`, block: true },
+    ]),
+    // DNS labels (including IDNA's ASCII spelling and underscore labels) have
+    // a nondigit character. Requiring a dot excludes canonical IPv6 literals;
+    // neither credentials nor a path/query can satisfy a hostname pattern.
+    ...[...'abcdefghijklmnopqrstuvwxyz-_'].map((character) => ({
+      urlPattern: `*://*.*${character}*:*/*`,
+      block: false,
+    })),
+  ];
+};


### PR DESCRIPTION
## Summary

Allow dotted DNS names with numeric labels to load when IPv4 network ranges are blocked. For example, `127.0.0.1.example.test` must not be treated as an IPv4 address.

- Add ordered hostname-aware CDP rules on the existing page session, without enabling Fetch interception or adding another session.
- Preserve scheme and hostname blocks, IPv4/IPv6 range checks, and port-specific self-host exemptions.
- Install the legacy blocklist first. Browsers without ordered-rule support and custom URL-prefix policies retain the existing conservative matching behavior.
- Keep pattern generation in Node and matching in Chromium; production code does not depend on Node's URLPattern API.

## Validation

- Full build, TypeScript, lint, and formatting checks pass.
- 58 focused tests pass under Node 24, including site/proxy authentication and a simulated unsupported-protocol fallback.
- A real Chromium proxy regression fails before the fix and passes afterward: numeric DNS requests reach the fixture while blocked IP requests do not.
- 20 additional Browserless route and scratch-directory tests pass with Chromium-only routes.
- The unrestricted local suite encountered startup failures because other browser binaries were not installed. The browser-image matrix is covered by CI.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Improved browser network protection for DNS lookalikes, metadata endpoints, IPv6 addresses, and protocol-based threats.
  * Added more precise URL blocking while preserving access to configured self-host addresses and ports.
  * Maintained conservative blocking behavior when advanced browser rules are unsupported or cannot be safely applied.

* **Bug Fixes**
  * Improved handling of numeric DNS labels and complex URL patterns to ensure blocked destinations remain protected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->