### PR TITLE
fix: reset stale debugger localStorage settings when a valid token is provided

### DIFF
--- a/src/routes/management/http/static.get.ts
+++ b/src/routes/management/http/static.get.ts
@@ -9,10 +9,11 @@ import {
   Request,
   contentTypes,
   fileExists,
+  getTokenFromRequest,
   mimeTypes,
 } from '@browserless.io/browserless';
+import { createReadStream, promises as fs } from 'fs';
 import { ServerResponse } from 'http';
-import { createReadStream } from 'fs';
 import path from 'path';
 
 const pathMap: Map<
@@ -22,6 +23,28 @@ const pathMap: Map<
     path: string;
   }
 > = new Map();
+
+// The debugger UI ignores a fresh ?token= once a Browser URL is saved to
+// localStorage (#5560); its repo is archived, so we patch the symptom here.
+const DEBUGGER_INDEX_PATHS = new Set(['/debugger/', '/debugger/index.html']);
+const DEBUGGER_TOKEN_RESET_SCRIPT =
+  "<script>if(new URLSearchParams(location.search).has('token')){Object.keys(localStorage).filter((k)=>k.startsWith('browserless-debugger')).forEach((k)=>localStorage.removeItem(k));}</script>";
+
+const injectDebuggerTokenResetScript = (
+  html: string,
+  logger: Logger,
+): string => {
+  if (/<head[^>]*>/i.test(html)) {
+    return html.replace(
+      /<head[^>]*>/i,
+      (tag) => `${tag}${DEBUGGER_TOKEN_RESET_SCRIPT}`,
+    );
+  }
+  logger.warn(
+    'Debugger index has no <head> tag; prepending the reset script instead',
+  );
+  return `${DEBUGGER_TOKEN_RESET_SCRIPT}${html}`;
+};
 
 const streamFile = (
   logger: Logger,
@@ -66,9 +89,26 @@ export default class StaticGetRoute extends HTTPRoute {
     logger: Logger,
   ): Promise<unknown> {
     const { pathname } = req.parsed;
+    const config = this.config();
+
+    // `?token=` never reaches req.parsed — moveTokenToHeader() (src/shim.ts)
+    // moves it to the Authorization header before routing. Compare against
+    // the configured token(s) rather than just checking for any
+    // Authorization header, since a proxy in front of browserless may set
+    // that header unconditionally for unrelated reasons.
+    const configuredToken = config.getToken();
+    const requestToken = getTokenFromRequest(req);
+    const resetDebuggerSettings =
+      DEBUGGER_INDEX_PATHS.has(pathname) &&
+      !!requestToken &&
+      configuredToken !== null &&
+      (Array.isArray(configuredToken)
+        ? configuredToken
+        : [configuredToken]
+      ).includes(requestToken);
     const fileCache = pathMap.get(pathname);
 
-    if (fileCache) {
+    if (fileCache && !resetDebuggerSettings) {
       return streamFile(logger, res, fileCache.path, fileCache.contentType);
     }
 
@@ -84,7 +124,6 @@ export default class StaticGetRoute extends HTTPRoute {
       return;
     }
 
-    const config = this.config();
     const sdkDir = this.staticSDKDir();
     const file = path.join(config.getStatic(), pathname);
     const indexFile = path.join(file, 'index.html');
@@ -134,6 +173,19 @@ export default class StaticGetRoute extends HTTPRoute {
       const location = req.parsed.pathname + '/' + (req.parsed.search || '');
       res.writeHead(301, { Location: location });
       res.end();
+      return;
+    }
+
+    if (resetDebuggerSettings) {
+      logger.debug(
+        `Serving debugger index with a localStorage reset script injected, since a valid token was provided`,
+      );
+      const html = await fs.readFile(foundFilePath, 'utf-8');
+      res.setHeader('Content-Type', 'text/html');
+      // The response content depends on the request's token, not just the
+      // URL, so it must never be cached by a browser, CDN or proxy.
+      res.setHeader('Cache-Control', 'no-store');
+      res.end(injectDebuggerTokenResetScript(html, logger));
       return;
     }
 

--- a/src/routes/management/tests/management.spec.ts
+++ b/src/routes/management/tests/management.spec.ts
@@ -306,6 +306,8 @@ describe('Management APIs', function () {
       const staticDir = await mkdtemp(
         path.join(os.tmpdir(), 'browserless-debugger-test-'),
       );
+      const previousStatic = process.env.STATIC;
+      const previousEnableDebugger = process.env.ENABLE_DEBUGGER;
 
       try {
         await mkdir(path.join(staticDir, 'debugger'));
@@ -351,8 +353,16 @@ describe('Management APIs', function () {
           'browserless-debugger',
         );
       } finally {
-        delete process.env.STATIC;
-        delete process.env.ENABLE_DEBUGGER;
+        if (previousStatic === undefined) {
+          delete process.env.STATIC;
+        } else {
+          process.env.STATIC = previousStatic;
+        }
+        if (previousEnableDebugger === undefined) {
+          delete process.env.ENABLE_DEBUGGER;
+        } else {
+          process.env.ENABLE_DEBUGGER = previousEnableDebugger;
+        }
         await rm(staticDir, { recursive: true, force: true });
       }
     });

--- a/src/routes/management/tests/management.spec.ts
+++ b/src/routes/management/tests/management.spec.ts
@@ -1,4 +1,7 @@
 import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
 import {
   exists,
   Browserless,
@@ -297,6 +300,61 @@ describe('Management APIs', function () {
 
       expect(res.status).to.equal(301);
       expect(res.headers.get('location')).to.equal('/debugger/');
+    });
+
+    it('injects a localStorage reset script into the debugger index when a token is provided', async () => {
+      const staticDir = await mkdtemp(
+        path.join(os.tmpdir(), 'browserless-debugger-test-'),
+      );
+
+      try {
+        await mkdir(path.join(staticDir, 'debugger'));
+        await writeFile(
+          path.join(staticDir, 'debugger', 'index.html'),
+          '<!DOCTYPE html><html><head><title>Debugger</title></head>' +
+            '<body><script src="app.js"></script></body></html>',
+        );
+
+        process.env.STATIC = staticDir;
+        process.env.ENABLE_DEBUGGER = 'true';
+        const config = new Config();
+        config.setToken('6R0W53R135510');
+
+        await start({ config });
+
+        const withToken = await fetch(
+          'http://localhost:3000/debugger/?token=6R0W53R135510',
+        );
+        expect(withToken.status).to.equal(200);
+        const withTokenHtml = await withToken.text();
+        expect(withTokenHtml).to.include('browserless-debugger');
+        expect(withTokenHtml).to.include('<title>Debugger</title>');
+        expect(withTokenHtml.indexOf('browserless-debugger')).to.be.lessThan(
+          withTokenHtml.indexOf('<title>Debugger</title>'),
+        );
+
+        expect(withToken.headers.get('cache-control')).to.equal('no-store');
+
+        const withoutToken = await fetch('http://localhost:3000/debugger/');
+        expect(withoutToken.status).to.equal(200);
+        const withoutTokenHtml = await withoutToken.text();
+        expect(withoutTokenHtml).to.not.include('browserless-debugger');
+
+        // A proxy in front of browserless may set its own Authorization
+        // header for unrelated reasons; that must not trigger the reset.
+        const withUnrelatedAuth = await fetch(
+          'http://localhost:3000/debugger/',
+          { headers: { Authorization: 'Bearer some-other-value' } },
+        );
+        expect(withUnrelatedAuth.status).to.equal(200);
+        expect(await withUnrelatedAuth.text()).to.not.include(
+          'browserless-debugger',
+        );
+      } finally {
+        delete process.env.STATIC;
+        delete process.env.ENABLE_DEBUGGER;
+        await rm(staticDir, { recursive: true, force: true });
+      }
     });
 
     it('redirects /docs to /docs/', async () => {


### PR DESCRIPTION
The bundled debugger UI (@browserless.io/debugger) persists its "Browser URL" to localStorage and never refreshes it from a fresh ?token= once anything has been saved, so a stale token-less URL silently shadows any token passed afterward (#5560). Its package repo is archived, so this patches the symptom server-side instead: when the debugger's index page is requested with a token matching the configured one, inject a small inline script that clears the persisted settings before the app boots.

The response is marked Cache-Control: no-store since its content now depends on the request's token, not just the URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Debugger pages accessed with a valid debugger token now clear stale connection settings before loading.
  * Token authentication works consistently, including tokens provided through authorization headers.
  * Existing debugger preferences, including open editor tabs, are preserved during the reset.
  * Token-authenticated debugger pages are served without caching so current settings are applied.
  * Requests without a valid debugger token continue to receive standard page behavior.
  * Improved handling for debugger pages without a `<head>` element or with malformed saved settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->